### PR TITLE
[WIP/POC] Add ability to customize syntax highligting via settings

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,12 @@
-MIT License
+Copyright 2019  HubSpot, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-Copyright (c) 2018 William Spiro
+   http://www.apache.org/licenses/LICENSE-2.0
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # HubL Visual Studio Code Language Extension
-Get it :point_right: https://marketplace.visualstudio.com/items?itemName=WilliamSpiro.hubl
+Get it :point_right: https://marketplace.visualstudio.com/items?itemName=HubSpot.hubl
 
 Check out how to get started with local development on the HubSpot CMS :point_right: https://designers.hubspot.com/docs/tools/local-development
 

--- a/main.js
+++ b/main.js
@@ -9,7 +9,36 @@ function activate() {
       decreaseIndentPattern: /.*{%(.*?end).*%}*./,
       increaseIndentPattern: /.*{%(?!.*end).*%}.*/,
     },
-  });
+	});
+
+	const override = {
+		"textMateRules": [
+			{
+				"scope": [
+					"meta.scope.hubl.variable",
+					"variable"
+				],
+				"settings": {
+					"foreground": "#e7ca6b"
+				}
+			}
+		]
+	};
+
+	vscode.workspace.onDidChangeConfiguration(e => {
+		if (e.affectsConfiguration('hubl.overrideSyntaxHighlight')) {
+			let hublConfig = vscode.workspace.getConfiguration('hubl');
+			let editorConfig = vscode.workspace.getConfiguration('editor');
+
+			if (hublConfig.get('overrideSyntaxHighlight') === true){
+				vscode.window.showInformationMessage('Override HubL Syntax On');
+				editorConfig.update('tokenColorCustomizations', override);
+			} else {
+				vscode.window.showInformationMessage('Override HubL Syntax Off');
+				editorConfig.update('tokenColorCustomizations', undefined);
+			}
+		}
+	});
 }
 
 function deactivate() {}

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "hubl",
     "displayName": "HubL Language Extension",
     "description": "HubL Visual Studio Code Language Extension",
-    "version": "0.1.4",
-    "publisher": "WilliamSpiro",
+    "version": "0.2.0",
+    "publisher": "HubSpot",
     "engines": {
         "vscode": "^1.30.0"
     },
@@ -14,9 +14,9 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/williamspiro/HubL-Language-Extension"
+        "url": "https://github.com/HubSpot/HubL-Language-Extension"
     },
-    "homepage": "https://github.com/williamspiro/HubL-Language-Extension/blob/master/README.md",
+    "homepage": "https://github.com/HubSpot/HubL-Language-Extension/blob/master/README.md",
     "categories": [
         "Snippets"
     ],

--- a/package.json
+++ b/package.json
@@ -84,14 +84,14 @@
                 "configuration": "./langconfig/language-configuration.json"
             },
             {
-                "id": "html",
+                "id": "html+hubl",
                 "extensions": [
                     ".html"
                 ],
                 "configuration": "./langconfig/language-configuration.json"
             },
             {
-                "id": "css",
+                "id": "css+hubl",
                 "extensions": [
                     ".css"
                 ],
@@ -119,7 +119,24 @@
                     "source.html"
                 ]
             }
-        ]
+        ],
+        "configuration": {
+            "title": "HubL",
+            "properties": {
+              "hubl.overrideSyntaxHighlight": {
+                "type": "boolean",
+                "default": false,
+                "description": "Overrides syntax highlighting."
+              },
+              "hubl.syntaxHighlightColors": {
+                "type": "object",
+                "default": {
+                    "delimeters": ""
+                },
+                "description": "Color overrides for syntax highlighting"
+              }
+            }
+          }
     },
     "dependencies": {
         "@types/vscode": "^1.47.0",


### PR DESCRIPTION
If a user has installed a VS Code theme that affects syntax highlighting color schemes, it is possible that the HubL highlighting might not work correctly (it _does work_ but colors might look the same for different types).

This PR aims to do two things:
- changes the file type from `HTML` to `HTML+HUBL` (still associated with `.html` files)
- adds settings to for users to override syntax highlighting colors used
![image](https://user-images.githubusercontent.com/9009552/89636509-b99c7300-d876-11ea-866e-a9f4a47fd074.png)

This is really just a proof of concept  at this stage but I'm wondering what folks might think about these changes?
@TanyaScales @TheWebTech @williamspiro 