### PR TITLE
Improve field snippets

### DIFF
--- a/snippets/man_gen/hubl_custom_module_fields.json
+++ b/snippets/man_gen/hubl_custom_module_fields.json
@@ -485,23 +485,6 @@
     ],
     "description": "HubSpot Custom Module: Tag Field"
   },
-  "Workflow Field": {
-    "prefix": "field.workflow",
-    "body": [
-      "{",
-      "\"id\" : \"\",",
-      "\"name\": \"${1:workflow_field}\",",
-      "\"label\": \"${2:Workflow field}\",",
-      "\"required\": false,",
-      "\"locked\": false,",
-      "\"inline_help_text\": \"\",",
-      "\"help_text\": \"\",",
-      "\"type\": \"workflow\",",
-      "\"placeholder\": \"\",",
-      "\"default\": null }"
-    ],
-    "description": "HubSpot Custom Module: Workflow Field"
-  },
   "Font Field": {
     "prefix": "field.font",
     "body": [

--- a/snippets/man_gen/hubl_custom_module_fields.json
+++ b/snippets/man_gen/hubl_custom_module_fields.json
@@ -10,9 +10,9 @@
       "\"locked\": false,",
       "\"children\": [${3}],",
       "\"type\": \"group\",",
-      "\"default\": {} }",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
-      "\"help_text\": \"\""
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\"",
+      "\"default\": {} }"
     ],
     "description": "HubSpot Custom Module: Field Group"
   },
@@ -33,9 +33,9 @@
       "},",
       "\"children\": [${3}],",
       "\"type\": \"group\",",
-      "\"default\": {} }",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
-      "\"help_text\": \"\""
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\"",
+      "\"default\": {} }"
     ],
     "description": "HubSpot Custom Module: Repeater Group"
   },
@@ -50,9 +50,9 @@
       "\"locked\": false,",
       "\"step\": 1,",
       "\"type\": \"date\",",
-      "\"default\": ${3:null} }",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
-      "\"help_text\": \"\""
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\",",
+      "\"default\": ${3:null} }"
     ],
     "description": "HubSpot Custom Module: Date field"
   },
@@ -67,9 +67,9 @@
       "\"locked\": false,",
       "\"step\": 30,",
       "\"type\": \"datetime\",",
-      "\"default\": ${3:null} }",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
-      "\"help_text\": \"\""
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\"",
+      "\"default\": ${3:null} }"
     ],
     "description": "HubSpot Custom Module: Date and Time Field"
   },
@@ -84,7 +84,7 @@
       "\"locked\" : false,",
       "\"supported_types\" : [ \"EXTERNAL\", \"CONTENT\", \"FILE\", \"EMAIL_ADDRESS\", \"BLOG\" ],",
       "\"type\" : \"link\",",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"default\" : {",
       "  \"url\" : {",
@@ -112,9 +112,9 @@
       "\"type\" : \"number\",",
       "\"min\" : ${4:null},",
       "\"max\" : ${5:null},",
-      "\"default\" : ${6:null} }",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
-      "\"help_text\": \"\""
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\",",
+      "\"default\" : ${6:null} }"
     ],
     "description": "HubSpot Custom Module: Number Field"
   },
@@ -128,9 +128,9 @@
       "\"required\": false,",
       "\"locked\": false,",
       "\"type\": \"richtext\",",
-      "\"default\": ${3:null} }",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
-      "\"help_text\": \"\""
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\",",
+      "\"default\": ${3:null} }"
     ],
     "description": "HubSpot Custom Module: Rich Text Field"
   },
@@ -148,9 +148,9 @@
       "\"show_emoji_picker\": false,",
       "\"type\": \"text\",",
       "\"placeholder\": \"\",",
-      "\"default\": ${3:null} }",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
-      "\"help_text\": \"\""
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\",",
+      "\"default\": ${3:null} }"
     ],
     "description": "HubSpot Custom Module: Text Field"
   },
@@ -164,9 +164,9 @@
       "\"required\": false,",
       "\"locked\": false,",
       "\"type\": \"simplemenu\",",
-      "\"default\": ${3:[]} }",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
-      "\"help_text\": \"\""
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\",",
+      "\"default\": ${3:[]} }"
     ],
     "description": "HubSpot Custom Module: Simple Menu"
   },
@@ -179,7 +179,7 @@
       "\"label\": \"${2:URL field}\",",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"supported_types\": [",
       "  \"EXTERNAL\",",
@@ -206,9 +206,9 @@
       "\"required\": false,",
       "\"locked\": false,",
       "\"type\": \"boolean\",",
-      "\"default\": ${3:false} }",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
-      "\"help_text\": \"\""
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\",",
+      "\"default\": ${3:false} }"
     ],
     "description": "HubSpot Custom Module: Boolean Field"
   },
@@ -222,7 +222,7 @@
       "\"required\": false,",
       "\"locked\": false,",
       "\"display\": \"select\",",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"choices\": [",
       "[",
@@ -251,7 +251,7 @@
       "\"locked\": false,",
       "\"type\": \"blog\",",
       "\"placeholder\": \"\",",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"default\": null }"
     ],
@@ -266,7 +266,7 @@
       "\"label\": \"${2:Color field}\",",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"type\": \"color\",",
       "\"default\": {",
@@ -284,7 +284,7 @@
       "\"label\": \"${2:CTA field}\",",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"type\": \"cta\",",
       "\"default\": null }"
@@ -300,7 +300,7 @@
       "\"label\": \"${2:Email Address Field}\",",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"type\": \"email\",",
       "\"placeholder\": \"\",",
@@ -317,7 +317,7 @@
       "\"name\": \"${1:file_field}\",",
       "\"label\": \"${2:File field}\",",
       "\"required\": false,",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"locked\": false,",
       "\"type\": \"file\",",
@@ -334,7 +334,7 @@
       "\"label\": \"${2:Followup email field}\",",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"type\": \"followupemail\",",
       "\"placeholder\": \"\",",
@@ -351,7 +351,7 @@
       "\"label\": \"${2:Form field}\",",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"type\": \"form\",",
       "\"default\": {",
@@ -369,7 +369,7 @@
       "\"label\": \"${2:HubDB table field}\",",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"type\": \"hubdbtable\",",
       "\"placeholder\": \"\",",
@@ -386,7 +386,7 @@
       "\"label\": \"${2:Icon field}\",",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"type\": \"icon\",",
       "\"default\": {} }"
@@ -402,7 +402,7 @@
       "\"label\": \"${2:Image field}\",",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"responsive\": true,",
       "\"resizable\": true,",
@@ -422,7 +422,7 @@
       "\"label\": \"${2:Logo field}\",",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"resizable\": true,",
       "\"type\": \"logo\",",
@@ -442,7 +442,7 @@
       "\"label\": \"${2:Menu field}\",",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"type\": \"menu\",",
       "\"placeholder\": \"\",",
@@ -459,7 +459,7 @@
       "\"label\": \"${2:Page field}\",",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"type\": \"page\",",
       "\"placeholder\": \"\",",
@@ -476,7 +476,7 @@
       "\"label\": \"${2:Tag field}\",",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"tag_value\": \"SLUG\",",
       "\"type\": \"tag\",",
@@ -494,7 +494,7 @@
       "\"label\": \"${2:Workflow field}\",",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"type\": \"workflow\",",
       "\"placeholder\": \"\",",
@@ -510,7 +510,7 @@
       "\"label\": \"${1:Font field}\",",
       "\"required\": false,",
       "\"locked\": false,",
-      "\"inline_help_text\": \"Shows Teaser image when toggled on\",",
+      "\"inline_help_text\": \"\",",
       "\"help_text\": \"\",",
       "\"load_external_fonts\": true,",
       "\"type\": \"font\",",

--- a/snippets/man_gen/hubl_custom_module_fields.json
+++ b/snippets/man_gen/hubl_custom_module_fields.json
@@ -3,7 +3,6 @@
     "prefix": "group.group",
     "body": [
       "{",
-      "\"id\": \"\",",
       "\"name\": \"${1:field_group}\",",
       "\"label\": \"${2:field_group}\",",
       "\"required\": false,",
@@ -20,7 +19,6 @@
     "prefix": "group.repeater",
     "body": [
       "{",
-      "\"id\": \"\",",
       "\"name\": \"${1:field_group}\",",
       "\"label\": \"${2:field_group}\",",
       "\"required\": false,",
@@ -43,7 +41,6 @@
     "prefix": "field.date",
     "body": [
       "{",
-      "\"id\": \" \",",
       "\"name\": \"${1:date_field}\",",
       "\"label\": \"${2:Date field}\",",
       "\"required\": false,",
@@ -60,7 +57,6 @@
     "prefix": "field.datetime",
     "body": [
       "{",
-      "\"id\": \"\",",
       "\"name\": \"${1:datetime_field}\",",
       "\"label\": \"${2:Date and time field}\",",
       "\"required\": false,",
@@ -77,7 +73,6 @@
     "prefix": "field.link",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\" : \"${1:link_field}\",",
       "\"label\" : \"${2:Link field}\",",
       "\"required\" : false,",
@@ -102,7 +97,6 @@
     "prefix": "field.number",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\" : \"${1:number_field}\",",
       "\"label\" : \"${2:Number field}\",",
       "\"required\" : false,",
@@ -122,7 +116,6 @@
     "prefix": "field.richtext",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:richtext_field}\",",
       "\"label\": \"${2:Rich text field}\",",
       "\"required\": false,",
@@ -138,7 +131,6 @@
     "prefix": "field.text",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:text_field}\",",
       "\"label\": \"${2:Text field}\",",
       "\"required\": false,",
@@ -158,7 +150,6 @@
     "prefix": "field.simplemenu",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:simplemenu_field}\",",
       "\"label\": \"${2:Simple menu field}\",",
       "\"required\": false,",
@@ -174,7 +165,6 @@
     "prefix": "field.url",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:url_field}\",",
       "\"label\": \"${2:URL field}\",",
       "\"required\": false,",
@@ -200,7 +190,6 @@
     "prefix": "field.boolean",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:boolean_field}\",",
       "\"label\": \"${2:Boolean field}\",",
       "\"required\": false,",
@@ -216,7 +205,6 @@
     "prefix": "field.choice",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:choice_field}\",",
       "\"label\": \"${2:Choice field}\",",
       "\"required\": false,",
@@ -244,7 +232,6 @@
     "prefix": "field.blog",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:blog_field}\",",
       "\"label\": \"${2:Blog field}\",",
       "\"required\": false,",
@@ -261,7 +248,6 @@
     "prefix": "field.color",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:color_field}\",",
       "\"label\": \"${2:Color field}\",",
       "\"required\": false,",
@@ -279,7 +265,6 @@
     "prefix": "field.cta",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:cta_field}\",",
       "\"label\": \"${2:CTA field}\",",
       "\"required\": false,",
@@ -295,7 +280,6 @@
     "prefix": "field.email",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:email_field}\",",
       "\"label\": \"${2:Email Address Field}\",",
       "\"required\": false,",
@@ -312,7 +296,6 @@
     "prefix": "field.file",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"picker\": \"file\",",
       "\"name\": \"${1:file_field}\",",
       "\"label\": \"${2:File field}\",",
@@ -329,7 +312,6 @@
     "prefix": "field.followup",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:followupemail_field}\",",
       "\"label\": \"${2:Followup email field}\",",
       "\"required\": false,",
@@ -346,7 +328,6 @@
     "prefix": "field.form",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:form_field}\",",
       "\"label\": \"${2:Form field}\",",
       "\"required\": false,",
@@ -364,7 +345,6 @@
     "prefix": "field.hubdb",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:hubdbtable_field}\",",
       "\"label\": \"${2:HubDB table field}\",",
       "\"required\": false,",
@@ -381,7 +361,6 @@
     "prefix": "field.icon",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:icon_field}\",",
       "\"label\": \"${2:Icon field}\",",
       "\"required\": false,",
@@ -397,7 +376,6 @@
     "prefix": "field.image",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:image_field}\",",
       "\"label\": \"${2:Image field}\",",
       "\"required\": false,",
@@ -417,7 +395,6 @@
     "prefix": "field.logo",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:logo_field}\",",
       "\"label\": \"${2:Logo field}\",",
       "\"required\": false,",
@@ -437,7 +414,6 @@
     "prefix": "field.menu",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:menu_field}\",",
       "\"label\": \"${2:Menu field}\",",
       "\"required\": false,",
@@ -454,7 +430,6 @@
     "prefix": "field.page",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:page_field}\",",
       "\"label\": \"${2:Page field}\",",
       "\"required\": false,",
@@ -471,7 +446,6 @@
     "prefix": "field.tag",
     "body": [
       "{",
-      "\"id\" : \"\",",
       "\"name\": \"${1:tag_field}\",",
       "\"label\": \"${2:Tag field}\",",
       "\"required\": false,",

--- a/snippets/man_gen/hubl_custom_module_fields.json
+++ b/snippets/man_gen/hubl_custom_module_fields.json
@@ -13,7 +13,7 @@
       "\"help_text\": \"\"",
       "\"default\": {} }"
     ],
-    "description": "HubSpot Custom Module: Field Group"
+    "description": "HubSpot Field Group"
   },
   "Repeater": {
     "prefix": "group.repeater",
@@ -35,7 +35,7 @@
       "\"help_text\": \"\"",
       "\"default\": {} }"
     ],
-    "description": "HubSpot Custom Module: Repeater Group"
+    "description": "HubSpot Repeater Group"
   },
   "Date Field": {
     "prefix": "field.date",
@@ -51,7 +51,7 @@
       "\"help_text\": \"\",",
       "\"default\": ${3:null} }"
     ],
-    "description": "HubSpot Custom Module: Date field"
+    "description": "HubSpot Date field"
   },
   "Date Time Field": {
     "prefix": "field.datetime",
@@ -67,7 +67,7 @@
       "\"help_text\": \"\"",
       "\"default\": ${3:null} }"
     ],
-    "description": "HubSpot Custom Module: Date and Time Field"
+    "description": "HubSpot Date and Time Field"
   },
   "Link Field": {
     "prefix": "field.link",
@@ -91,7 +91,7 @@
       "  \"no_follow\" : false",
       "} }"
     ],
-    "description": "HubSpot Custom Module: Link Field"
+    "description": "HubSpot Link Field"
   },
   "Number Field": {
     "prefix": "field.number",
@@ -110,7 +110,7 @@
       "\"help_text\": \"\",",
       "\"default\" : ${6:null} }"
     ],
-    "description": "HubSpot Custom Module: Number Field"
+    "description": "HubSpot Number Field"
   },
   "Rich Text Field": {
     "prefix": "field.richtext",
@@ -125,7 +125,7 @@
       "\"help_text\": \"\",",
       "\"default\": ${3:null} }"
     ],
-    "description": "HubSpot Custom Module: Rich Text Field"
+    "description": "HubSpot Rich Text Field"
   },
   "Text Field": {
     "prefix": "field.text",
@@ -144,7 +144,7 @@
       "\"help_text\": \"\",",
       "\"default\": ${3:null} }"
     ],
-    "description": "HubSpot Custom Module: Text Field"
+    "description": "HubSpot Text Field"
   },
   "Simple Menu": {
     "prefix": "field.simplemenu",
@@ -159,7 +159,7 @@
       "\"help_text\": \"\",",
       "\"default\": ${3:[]} }"
     ],
-    "description": "HubSpot Custom Module: Simple Menu"
+    "description": "HubSpot Simple Menu"
   },
   "Url Field": {
     "prefix": "field.url",
@@ -184,7 +184,7 @@
       "  \"href\": \"\",",
       "  \"type\": \"${3|EXTERNAL,CONTENT,FILE,EMAIL_ADDRESS,BLOG|}\"} }"
     ],
-    "description": "HubSpot Custom Module: Url Field"
+    "description": "HubSpot Url Field"
   },
   "Boolean Field": {
     "prefix": "field.boolean",
@@ -199,7 +199,7 @@
       "\"help_text\": \"\",",
       "\"default\": ${3:false} }"
     ],
-    "description": "HubSpot Custom Module: Boolean Field"
+    "description": "HubSpot Boolean Field"
   },
   "Choice Field": {
     "prefix": "field.choice",
@@ -226,7 +226,7 @@
       "\"placeholder\": \"\",",
       "\"default\": null }"
     ],
-    "description": "HubSpot Custom Module: Choice Field"
+    "description": "HubSpot Choice Field"
   },
   "Blog Field": {
     "prefix": "field.blog",
@@ -242,7 +242,7 @@
       "\"help_text\": \"\",",
       "\"default\": null }"
     ],
-    "description": "HubSpot Custom Module: Blog Field"
+    "description": "HubSpot Blog Field"
   },
   "Color Field": {
     "prefix": "field.color",
@@ -259,7 +259,7 @@
       "  \"color\": \"${3:#ffffff\"},",
       "  \"opacity\": ${4:100} } }"
     ],
-    "description": "HubSpot Custom Module: Color Field"
+    "description": "HubSpot Color Field"
   },
   "CTA Field": {
     "prefix": "field.cta",
@@ -274,7 +274,7 @@
       "\"type\": \"cta\",",
       "\"default\": null }"
     ],
-    "description": "HubSpot Custom Module: CTA Field"
+    "description": "HubSpot CTA Field"
   },
   "Email Field": {
     "prefix": "field.email",
@@ -290,7 +290,7 @@
       "\"placeholder\": \"\",",
       "\"default\": null }"
     ],
-    "description": "HubSpot Custom Module: Email Field"
+    "description": "HubSpot Email Field"
   },
   "File Field": {
     "prefix": "field.file",
@@ -306,7 +306,7 @@
       "\"type\": \"file\",",
       "\"default\": null }"
     ],
-    "description": "HubSpot Custom Module: File"
+    "description": "HubSpot File"
   },
   "Followup Email Field": {
     "prefix": "field.followup",
@@ -322,7 +322,7 @@
       "\"placeholder\": \"\",",
       "\"default\": null }"
     ],
-    "description": "HubSpot Custom Module: Followup Email"
+    "description": "HubSpot Followup Email"
   },
   "Form Field": {
     "prefix": "field.form",
@@ -339,7 +339,7 @@
       "  \"response_type\": \"inline\",",
       "  \"message\": \"Thanks for submitting the form.\" } }"
     ],
-    "description": "HubSpot Custom Module: Form Field"
+    "description": "HubSpot Form Field"
   },
   "HubDB Table Field": {
     "prefix": "field.hubdb",
@@ -355,7 +355,7 @@
       "\"placeholder\": \"\",",
       "\"default\": null }"
     ],
-    "description": "HubSpot Custom Module: HubDB Table"
+    "description": "HubSpot HubDB Table"
   },
   "Icon Field": {
     "prefix": "field.icon",
@@ -370,7 +370,7 @@
       "\"type\": \"icon\",",
       "\"default\": {} }"
     ],
-    "description": "HubSpot Custom Module: Icon Field"
+    "description": "HubSpot Icon Field"
   },
   "Image Field": {
     "prefix": "field.image",
@@ -389,7 +389,7 @@
       "  \"src\": ${3:\"\"},",
       "  \"alt\": ${4:null}} }"
     ],
-    "description": "HubSpot Custom Module: Image Field"
+    "description": "HubSpot Image Field"
   },
   "Logo Field": {
     "prefix": "field.logo",
@@ -408,7 +408,7 @@
       "  \"src\": null,",
       "  \"alt\": null } }"
     ],
-    "description": "HubSpot Custom Module: Logo Field"
+    "description": "HubSpot Logo Field"
   },
   "Menu Field": {
     "prefix": "field.menu",
@@ -424,7 +424,7 @@
       "\"placeholder\": \"\",",
       "\"default\": null }"
     ],
-    "description": "HubSpot Custom Module: Menu Field"
+    "description": "HubSpot Menu Field"
   },
   "Page Field": {
     "prefix": "field.page",
@@ -440,7 +440,7 @@
       "\"placeholder\": \"\",",
       "\"default\": null }"
     ],
-    "description": "HubSpot Custom Module: Page Field"
+    "description": "HubSpot Page Field"
   },
   "Tag Field": {
     "prefix": "field.tag",
@@ -457,7 +457,7 @@
       "\"placeholder\": \"\",",
       "\"default\": null }"
     ],
-    "description": "HubSpot Custom Module: Tag Field"
+    "description": "HubSpot Tag Field"
   },
   "Font Field": {
     "prefix": "field.font",
@@ -481,6 +481,6 @@
       "}",
       "}"
     ],
-    "description": "HubSpot Custom Module: Font Field"
+    "description": "HubSpot Font Field"
   }
 }


### PR DESCRIPTION
This PR does the following:

1. Removes the workflow field
2. Removes `id` property from field snippets
3. Tightens up the descriptions to make them shorter and more general since they can be used for themes and modules

Fixes #64

@williamspiro @miketalley