### PR TITLE
Switch snippets to single quotes

### DIFF
--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -47,10 +47,10 @@ const buildSnippetBody = (
 
       if (type == 'tags') {
         return (
-          '\n\t' + param.name + '=\'${' + paramIndex + ':' + param.name + '}\''
+          '\n\t' + param.name + "='${" + paramIndex + ':' + param.name + "}'"
         );
       } else if (param.type == 'String') {
-        return '\'${' + paramIndex + ':' + param.name + '}\'';
+        return "'${" + paramIndex + ':' + param.name + "}'";
       } else {
         return '${' + paramIndex + ':' + param.name + '}';
       }

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -47,10 +47,10 @@ const buildSnippetBody = (
 
       if (type == 'tags') {
         return (
-          '\n\t' + param.name + '="${' + paramIndex + ':' + param.name + '}"'
+          '\n\t' + param.name + '=\'${' + paramIndex + ':' + param.name + '}\''
         );
       } else if (param.type == 'String') {
-        return '"${' + paramIndex + ':' + param.name + '}"';
+        return '\'${' + paramIndex + ':' + param.name + '}\'';
       } else {
         return '${' + paramIndex + ':' + param.name + '}';
       }
@@ -68,9 +68,9 @@ const buildSnippetBody = (
       return `${name}(${prettyParams()})`;
     case 'tags':
       if (endTag) {
-        return `{% ${name} "my_${name}" ${prettyParams()}%}\n\n{% ${endTag} %}`;
+        return `{% ${name} 'my_${name}' ${prettyParams()}%}\n\n{% ${endTag} %}`;
       } else {
-        return `{% ${name} "my_${name}" ${prettyParams()}%}`;
+        return `{% ${name} 'my_${name}' ${prettyParams()}%}`;
       }
   }
 };

--- a/snippets/auto_gen/hubl_expTests.json
+++ b/snippets/auto_gen/hubl_expTests.json
@@ -1,4 +1,53 @@
 {
+  "!=": {
+    "body": [
+      "!="
+    ],
+    "description": "",
+    "prefix": "!="
+  },
+  "<": {
+    "body": [
+      "<"
+    ],
+    "description": "",
+    "prefix": "<"
+  },
+  "<=": {
+    "body": [
+      "<="
+    ],
+    "description": "",
+    "prefix": "<="
+  },
+  "==": {
+    "body": [
+      "=="
+    ],
+    "description": "",
+    "prefix": "=="
+  },
+  ">": {
+    "body": [
+      ">"
+    ],
+    "description": "",
+    "prefix": ">"
+  },
+  ">=": {
+    "body": [
+      ">="
+    ],
+    "description": "",
+    "prefix": ">="
+  },
+  "boolean": {
+    "body": [
+      "boolean"
+    ],
+    "description": "Return true if object is a boolean (in a strict sense, not in its ability to evaluate to a truthy expression)",
+    "prefix": "boolean"
+  },
   "containing": {
     "body": [
       "containing"
@@ -27,6 +76,13 @@
     "description": "Returns true if a variable is divisible by a number\nParameters:\n- divisor(number) The number to check whether a number is divisible by",
     "prefix": "divisibleby"
   },
+  "eq": {
+    "body": [
+      "eq"
+    ],
+    "description": "",
+    "prefix": "eq"
+  },
   "equalto": {
     "body": [
       "equalto"
@@ -41,12 +97,75 @@
     "description": "Returns true if the value is even",
     "prefix": "even"
   },
+  "false": {
+    "body": [
+      "false"
+    ],
+    "description": "Return true if object is a boolean and false",
+    "prefix": "false"
+  },
+  "float": {
+    "body": [
+      "float"
+    ],
+    "description": "Return true if object is a float",
+    "prefix": "float"
+  },
+  "ge": {
+    "body": [
+      "ge"
+    ],
+    "description": "Returns true if the first object's value is greater than or equal to the second object's value\nParameters:\n- other(object) Another object to compare against",
+    "prefix": "ge"
+  },
+  "greaterthan": {
+    "body": [
+      "greaterthan"
+    ],
+    "description": "",
+    "prefix": "greaterthan"
+  },
+  "gt": {
+    "body": [
+      "gt"
+    ],
+    "description": "Returns true if the first object's value is strictly greater than the second\nParameters:\n- other(object) Another object to compare against",
+    "prefix": "gt"
+  },
+  "in": {
+    "body": [
+      "in"
+    ],
+    "description": "Returns true if value is contained in the iterable\nParameters:\n- list(object) The iterable to check for the value",
+    "prefix": "in"
+  },
+  "integer": {
+    "body": [
+      "integer"
+    ],
+    "description": "Return true if object is an integer or long",
+    "prefix": "integer"
+  },
   "iterable": {
     "body": [
       "iterable"
     ],
     "description": "Return true if the object is iterable (sequence, dict, etc)",
     "prefix": "iterable"
+  },
+  "le": {
+    "body": [
+      "le"
+    ],
+    "description": "Returns true if the first object's value is less than or equal to the second object's value\nParameters:\n- other(object) Another object to compare against",
+    "prefix": "le"
+  },
+  "lessthan": {
+    "body": [
+      "lessthan"
+    ],
+    "description": "",
+    "prefix": "lessthan"
   },
   "lower": {
     "body": [
@@ -55,12 +174,26 @@
     "description": "Return true if the given string is all lowercase",
     "prefix": "lower"
   },
+  "lt": {
+    "body": [
+      "lt"
+    ],
+    "description": "Returns true if the first object's value is strictly less than the second\nParameters:\n- other(object) Another object to compare against",
+    "prefix": "lt"
+  },
   "mapping": {
     "body": [
       "mapping"
     ],
     "description": "Return true if the given object is a dict",
     "prefix": "mapping"
+  },
+  "ne": {
+    "body": [
+      "ne"
+    ],
+    "description": "Returns true if an object has the different value from another object\nParameters:\n- other(object) Another object to check inequality against",
+    "prefix": "ne"
   },
   "none": {
     "body": [
@@ -118,6 +251,13 @@
     "description": "Return true if object is a string which starts with a specified other string\nParameters:\n- check(string) A second string to check is the start of the first string",
     "prefix": "string_startingwith"
   },
+  "true": {
+    "body": [
+      "true"
+    ],
+    "description": "Return true if object is a boolean and true",
+    "prefix": "true"
+  },
   "truthy": {
     "body": [
       "truthy"
@@ -143,7 +283,7 @@
     "body": [
       "within"
     ],
-    "description": "Returns true if a value is within a list\nParameters:\n- list(list) A list to check if the value is in.",
+    "description": "",
     "prefix": "within"
   }
 }

--- a/snippets/auto_gen/hubl_filters.json
+++ b/snippets/auto_gen/hubl_filters.json
@@ -15,21 +15,21 @@
   },
   "attr": {
     "body": [
-      "|attr(\"${1:name}\")"
+      "|attr('${1:name}')"
     ],
     "description": "Renders the attribute of a dictionary\nParameters:\n- name(String) The dictionary attribute name to access",
     "prefix": "|attr"
   },
   "batch": {
     "body": [
-      "|batch(${1:linecount}, \"${2:fill_with}\")"
+      "|batch(${1:linecount}, '${2:fill_with}')"
     ],
     "description": "A filter that groups up items within a sequence\nParameters:\n- linecount(number) Number of items to include in the batch\n- fill_with(String) Value used to fill up missing items",
     "prefix": "|batch"
   },
   "between_times": {
     "body": [
-      "|between_times(\"${1:end}\", \"${2:unit}\")"
+      "|between_times('${1:end}', '${2:unit}')"
     ],
     "description": "Calculates the time between two datetime objects\nParameters:\n- end(String) Datetime object or timestamp at the end of the period\n- unit(String) Which temporal unit to use",
     "prefix": "|between_times"
@@ -71,7 +71,7 @@
   },
   "cut": {
     "body": [
-      "|cut(\"${1:to_remove}\")"
+      "|cut('${1:to_remove}')"
     ],
     "description": "Removes a string from the value from another string\nParameters:\n- to_remove(String) String to remove from the original string",
     "prefix": "|cut"
@@ -92,16 +92,16 @@
   },
   "datetimeformat": {
     "body": [
-      "|datetimeformat(\"${1:format}\", \"${2:timezone}\", ${3:locale})"
+      "|datetimeformat('${1:format}', '${2:timezone}', ${3:locale})"
     ],
     "description": "Formats a date object\nParameters:\n- format(String) The format of the date determined by the directives added to this parameter\n- timezone(String) Time zone of output date\n- locale(string) The language code to use when formatting the datetime",
     "prefix": "|datetimeformat"
   },
   "default": {
     "body": [
-      "|default(\"${1:default_value}\", ${2:boolean})"
+      "|default(${1:default_value}, ${2:truthy})"
     ],
-    "description": "If the value is undefined it will return the passed default value, otherwise the value of the variable\nParameters:\n- default_value(String) Value to print when variable is not defined\n- boolean(boolean) Set to True to use with variables which evaluate to false",
+    "description": "If the value is undefined it will return the passed default value, otherwise the value of the variable\nParameters:\n- default_value(object) Value to print when variable is not defined\n- truthy(boolean) Set to True to use with variables which evaluate to false",
     "prefix": "|default"
   },
   "dictsort": {
@@ -204,9 +204,9 @@
   },
   "format_currency": {
     "body": [
-      "|format_currency(\"${1:locale}\", \"${2:currency code}\")"
+      "|format_currency('${1:locale}', '${2:currency code}', '${3:use default decimal digits}')"
     ],
-    "description": "Formats a given number as a currency based on the locale and currency code passed in as a parameter. \nParameters:\n- locale(String) Locale in which to format the currency. Any Java locale language tag can be passed as a parameter. The default is the page's locale.Format : ISO639LanguageCodeInLowercase-ISO3166CountryCodeInUppercase\n- currency_code(String) The ISO 4217 code of the currency. The default is the portal's default currency",
+    "description": "Formats a given number as a currency based on the locale and currency code passed in as a parameter. \nParameters:\n- locale(String) Locale in which to format the currency. Any Java locale language tag can be passed as a parameter. The default is the page's locale.Format : ISO639LanguageCodeInLowercase-ISO3166CountryCodeInUppercase\n- currency_code(String) The ISO 4217 code of the currency. The default is the portal's default currency\n- use_default decimal digits(String) A boolean input that determines if formatter needs to use default decimal digits of the currency code. The default is false.",
     "prefix": "|format_currency"
   },
   "fromjson": {
@@ -215,6 +215,13 @@
     ],
     "description": "Converts JSON string to Object",
     "prefix": "|fromjson"
+  },
+  "fromyaml": {
+    "body": [
+      "|fromyaml"
+    ],
+    "description": "Converts a YAML string to an object",
+    "prefix": "|fromyaml"
   },
   "geo_distance": {
     "body": [
@@ -225,7 +232,7 @@
   },
   "groupby": {
     "body": [
-      "|groupby(\"${1:attribute}\")"
+      "|groupby('${1:attribute}')"
     ],
     "description": "Group a sequence of objects by a common attribute.\nParameters:\n- attribute(String) The common attribute to group by",
     "prefix": "|groupby"
@@ -274,7 +281,7 @@
   },
   "join": {
     "body": [
-      "|join(\"${1:d}\", \"${2:attr}\")"
+      "|join('${1:d}', '${2:attr}')"
     ],
     "description": "Return a string which is the concatenation of the strings in the sequence.\nParameters:\n- d(String) The separator string used to join the items\n- attr(String) Optional dict object attribute to use in joining",
     "prefix": "|join"
@@ -316,7 +323,7 @@
   },
   "map": {
     "body": [
-      "|map(\"${1:attribute}\")"
+      "|map('${1:attribute}')"
     ],
     "description": "Applies a filter on a sequence of objects or looks up an attribute.\nParameters:\n- attribute(String) Filter to apply to an object or dict attribute to lookup",
     "prefix": "|map"
@@ -330,7 +337,7 @@
   },
   "minus_time": {
     "body": [
-      "|minus_time(\"${1:diff}\", \"${2:unit}\")"
+      "|minus_time('${1:diff}', '${2:unit}')"
     ],
     "description": "Subtracts a specified amount of time to a datetime object\nParameters:\n- diff(String) The amount to subtract from the datetime\n- unit(String) Which temporal unit to use",
     "prefix": "|minus_time"
@@ -344,7 +351,7 @@
   },
   "plus_time": {
     "body": [
-      "|plus_time(\"${1:diff}\", \"${2:unit}\")"
+      "|plus_time('${1:diff}', '${2:unit}')"
     ],
     "description": "Adds a specified amount of time to a datetime object\nParameters:\n- diff(String) The amount to add to the datetime\n- unit(String) Which temporal unit to use",
     "prefix": "|plus_time"
@@ -365,7 +372,7 @@
   },
   "regex_replace": {
     "body": [
-      "|regex_replace(\"${1:regex}\", \"${2:new}\")"
+      "|regex_replace('${1:regex}', '${2:new}')"
     ],
     "description": "Return a copy of the value with all occurrences of a matched regular expression (Java RE2 syntax) replaced with a new one. The first argument is the regular expression to be matched, the second is the replacement string\nParameters:\n- regex(String) The regular expression that you want to match and replace\n- new(String) The new string that you replace the matched substring",
     "prefix": "|regex_replace"
@@ -379,14 +386,14 @@
   },
   "rejectattr": {
     "body": [
-      "|rejectattr(\"${1:attribute}\", ${2:exp_test})"
+      "|rejectattr('${1:attribute}', ${2:exp_test})"
     ],
     "description": "Filters a sequence of objects by applying a test to an attribute of an object or the attribute and rejecting the ones with the test succeeding.\nParameters:\n- attribute(String) Attribute to test for and reject items that contain it\n- exp_test(name of expression test) Specify which expression test to run for making the rejection",
     "prefix": "|rejectattr"
   },
   "replace": {
     "body": [
-      "|replace(\"${1:old}\", \"${2:new}\", ${3:count})"
+      "|replace('${1:old}', '${2:new}', ${3:count})"
     ],
     "description": "Return a copy of the value with all occurrences of a substring replaced with a new one. The first argument is the substring that should be replaced, the second is the replacement string. If the optional third argument count is given, only the first count occurrences are replaced\nParameters:\n- old(String) The old substring that you want to match and replace\n- new(String) The new string that you replace the matched substring\n- count(number) Replace only the first N occurrences",
     "prefix": "|replace"
@@ -428,7 +435,7 @@
   },
   "selectattr": {
     "body": [
-      "|selectattr(\"${1:attr}\", ${2:exp_test})"
+      "|selectattr('${1:attr}', ${2:exp_test})"
     ],
     "description": "Filters a sequence of objects by applying a test to an attribute of an object and only selecting the ones with the test succeeding.\nParameters:\n- attr(String) Attribute to test for and select items that contain it\n- exp_test(name of expression test) Specify which expression test to run for making the selection",
     "prefix": "|selectattr"
@@ -449,14 +456,14 @@
   },
   "sort": {
     "body": [
-      "|sort(${1:reverse}, ${2:case_sensitive}, \"${3:attribute}\")"
+      "|sort(${1:reverse}, ${2:case_sensitive}, '${3:attribute}')"
     ],
     "description": "Sort an iterable.\nParameters:\n- reverse(boolean) Boolean to reverse the sort order\n- case_sensitive(boolean) Determines whether or not the sorting is case sensitive\n- attribute(String) Specifies an attribute to sort by",
     "prefix": "|sort"
   },
   "split": {
     "body": [
-      "|split(\"${1:separator}\", ${2:limit})"
+      "|split('${1:separator}', ${2:limit})"
     ],
     "description": "Splits the input string into a list on the given separator\nParameters:\n- separator(String) Specifies the separator to split the variable by\n- limit(number) Limits resulting list by putting remainder of string into last list item",
     "prefix": "|split"
@@ -477,14 +484,14 @@
   },
   "strtotime": {
     "body": [
-      "|strtotime(\"${1:datetimeFormat}\")"
+      "|strtotime('${1:datetimeFormat}')"
     ],
     "description": "Converts a datetime string and datetime format to a datetime object\nParameters:\n- datetimeFormat(String) Format of the datetime string",
     "prefix": "|strtotime"
   },
   "sum": {
     "body": [
-      "|sum(${1:start}, \"${2:attribute}\")"
+      "|sum(${1:start}, '${2:attribute}')"
     ],
     "description": "Returns the sum of a sequence of numbers plus the value of parameter ‘start’ (which defaults to 0). When the sequence is empty it returns start.\nParameters:\n- start(number) Sets a value to return, if there is nothing in the variable to sum\n- attribute(String) Specify an optional attribute of dict to sum",
     "prefix": "|sum"
@@ -510,6 +517,13 @@
     "description": "Writes object as a JSON string",
     "prefix": "|tojson"
   },
+  "toyaml": {
+    "body": [
+      "|toyaml"
+    ],
+    "description": "Writes object as a YAML string",
+    "prefix": "|toyaml"
+  },
   "trim": {
     "body": [
       "|trim"
@@ -519,14 +533,14 @@
   },
   "truncate": {
     "body": [
-      "|truncate(${1:length}, ${2:killwords}, \"${3:end}\")"
+      "|truncate(${1:length}, ${2:killwords}, '${3:end}')"
     ],
     "description": "Return a truncated copy of the string. The length is specified with the first parameter which defaults to 255. If the second parameter is true the filter will cut the text at length. Otherwise it will discard the last word. If the text was in fact truncated it will append an ellipsis sign (\"...\"). If you want a different ellipsis sign than \"...\" you can specify it using the third parameter.\nParameters:\n- length(number) Specifies the length at which to truncate the text (includes HTML characters)\n- killwords(boolean) If true, the string will cut text at length\n- end(String) The characters that will be added to indicate where the text was truncated",
     "prefix": "|truncate"
   },
   "truncatehtml": {
     "body": [
-      "|truncatehtml(${1:length}, \"${2:end}\", ${3:breakword})"
+      "|truncatehtml(${1:length}, '${2:end}', ${3:breakword})"
     ],
     "description": "Truncates a given string, respecting html markup (i.e. will properly close all nested tags)\nParameters:\n- length(number) Length at which to truncate text (HTML characters not included)\n- end(String) The characters that will be added to indicate where the text was truncated\n- breakword(boolean) If set to true, text will be truncated in the middle of words",
     "prefix": "|truncatehtml"
@@ -568,7 +582,7 @@
   },
   "urlize": {
     "body": [
-      "|urlize(${1:trim_url_limit}, ${2:nofollow}, \"${3:target}\")"
+      "|urlize(${1:trim_url_limit}, ${2:nofollow}, '${3:target}')"
     ],
     "description": "Converts URLs in plain text into clickable links.\nParameters:\n- trim_url_limit(number) Sets a character limit\n- nofollow(boolean) Adds nofollow to generated link tag\n- target(String) Adds target attr to generated link tag",
     "prefix": "|urlize"

--- a/snippets/auto_gen/hubl_functions.json
+++ b/snippets/auto_gen/hubl_functions.json
@@ -134,9 +134,9 @@
   },
   "crm_associations": {
     "body": [
-      "crm_associations(${1:id}, ${2:association type id}, ${3:query}, ${4:properties}, ${5:formatting})"
+      "crm_associations(${1:id}, ${2:association category}, ${3:association type id}, ${4:query}, ${5:properties}, ${6:formatting})"
     ],
-    "description": "Gets a list of objects associated to the id passed in from the HubSpot CRM\nParameters:\n- id(id) id of object to find associations from\n- association_type id(number) id of the association type to use\n- query(string) Optional. Query string delimited by '&'. All expressions are ANDed together. Supported operators are eq (default), neq, lt, lte, gt, gte, is_null and not_null\n- properties(string) Optional. A comma-separated list of properties to return. By default, a small set of common properties are returned. The id property is always returned.\n- formatting(boolean) Optional. Format values such as dates and currency according to this portal's settings. Omit or pass 'false' for raw strings.",
+    "description": "Gets a list of objects associated to the id passed in from the HubSpot CRM\nParameters:\n- id(id) id of object to find associations from\n- association_category(enumeration) The category of the association definition. Only HUBSPOT_DEFINED is supported at this time.\n- association_type id(number) id of the association type to use\n- query(string) Optional. Query string delimited by '&'. All expressions are ANDed together. Supported operators are eq (default), neq, lt, lte, gt, gte, is_null and not_null\n- properties(string) Optional. A comma-separated list of properties to return. By default, a small set of common properties are returned. The id property is always returned.\n- formatting(boolean) Optional. Format values such as dates and currency according to this portal's settings. Omit or pass 'false' for raw strings.",
     "prefix": "~crm_associations"
   },
   "crm_object": {
@@ -153,16 +153,30 @@
     "description": "Gets a list of object from the HubSpot CRM by query. For security, only product objects can be retrieved on any public page. Any other object type must be hosted on a page which is either password protected or requires a CMS Membership login. Objects are returned as a list of dicts of properties and values.To page through results, use limit and offset parameters on the query like limit=10&offset=20\nParameters:\n- object_type(string) Case-insensitive. contact, product, company, deal, ticket or quote\n- query(string) Optional. A query string, delimited by '&'. All expressions are ANDed together. Supported operators are eq (default), neq, lt, lte, gt, gte, is_null and not_null. If the query is not provided, the function will run the default query `offset=0&limit=10` to fetch the objects.\n- properties(string) A comma-separated list of properties to return. By default, a small set of common properties are returned. The id property is always returned.\n- formatting(boolean) Format values such as dates and currency according to this portal's settings. Omit or pass 'false' for raw strings.",
     "prefix": "~crm_objects"
   },
+  "crm_property_definition": {
+    "body": [
+      "crm_property_definition(${1:object type}, ${2:property name})"
+    ],
+    "description": "Gets the property definition for a given object type and property name. Supported object types are HubSpot built-in objects, portal specific objects, and integrator objects.For security, only portal specific objects and product can be retrieved on any public page. Any other built-in object types (except product) or integrator object types must be hosted on a page which is either password protected or requires a CMS Membership login. \nParameters:\n- object_type(string) The object type name e.g. 'contact', 'product', 'house_listing', 'publication', 'store_location'. For integrator object types the fully qualified name (FQN) should be used that is the type name prefixed by the app id, e.g. a34343_shipment. The only other case that the FQN should be used is when a portal specific custom object type has the same name as a HubSpot built-in object type, e.g. if a portal specific 'product' object type is needed then the FQN should be used instead of the simple type name like: p129292_contact (the number after the prefix 'p' is the portal id). Since the FQN of portal specific type carries the portal id, It is advised to avoid using the FQN for portal specific types to make the code portable across portals. Object type names are case sensitive except for built-in object types provided by HubSpot, e.g. 'CONTACT' and 'contact' refer to the same object type but 'House_Listing' is different than 'house_listing'\n- property_name(string) The case-insensitive property name to retrieve the definition for. ",
+    "prefix": "~crm_property_definition"
+  },
+  "crm_property_definitions": {
+    "body": [
+      "crm_property_definitions(${1:object type}, ${2:property name})"
+    ],
+    "description": "Gets the property definitions for a given object type and set of property names. Supported object types are HubSpot built-in objects, portal specific objects, and integrator objects.For security, only portal specific objects and product can be retrieved on any public page. Any other built-in object types (except product) or integrator object types must be hosted on a page which is either password protected or requires a CMS Membership login. \nParameters:\n- object_type(string) The object type name e.g. 'contact', 'product', 'house_listing', 'publication', 'store_location'. For integrator object types the fully qualified name (FQN) should be used that is the type name prefixed by the app id, e.g. a34343_shipment. The only other case that the FQN should be used is when a portal specific custom object type has the same name as a HubSpot built-in object type, e.g. if a portal specific 'product' object type is needed then the FQN should be used instead of the simple type name like: p129292_contact (the number after the prefix 'p' is the portal id). Since the FQN of portal specific type carries the portal id, It is advised to avoid using the FQN for portal specific types to make the code portable across portals. Object type names are case sensitive except for built-in object types provided by HubSpot, e.g. 'CONTACT' and 'contact' refer to the same object type but 'House_Listing' is different than 'house_listing'\n- property_name(string) Optional. The case-insensitive property names to retrieve the definition for. If empty, the definitions for all the properties will be retrieved.",
+    "prefix": "~crm_property_definitions"
+  },
   "cta": {
     "body": [
-      "cta(\"${1:guid}\", ${2:align_opt})"
+      "cta('${1:guid}', ${2:align_opt})"
     ],
     "description": "Renders a call to action embed tag\nParameters:\n- guid(String) The ID of the CTA to render\n- align_opt(enum justifyleft|justifycenter|justifyright|justifyfull) Adjusts alignment of CTA",
     "prefix": "~cta"
   },
   "datetimeformat": {
     "body": [
-      "datetimeformat(${1:var}, \"${2:format}\", \"${3:timezone}\")"
+      "datetimeformat(${1:var}, '${2:format}', '${3:timezone}')"
     ],
     "description": "formats a date to a string\nParameters:\n- var(date) \n- format(String) \n- timezone(String) Time zone of output date",
     "prefix": "~datetimeformat"
@@ -204,7 +218,7 @@
   },
   "get_asset_url": {
     "body": [
-      "get_asset_url(\"${1:path}\")"
+      "get_asset_url('${1:path}')"
     ],
     "description": "Returns URL to specified asset by given path\nParameters:\n- path(String) The Design Manager file path to the template or file",
     "prefix": "~get_asset_url"
@@ -253,7 +267,7 @@
   },
   "hubdb_table_column": {
     "body": [
-      "hubdb_table_column(${1:table_id}, \"${2:column}\")"
+      "hubdb_table_column(${1:table_id}, '${2:column}')"
     ],
     "description": "Returns column information for specific column in a table\nParameters:\n- table_id(string) id or name of the table\n- column(String) id or name of the column",
     "prefix": "~hubdb_table_column"
@@ -281,21 +295,21 @@
   },
   "i18n_getmessage": {
     "body": [
-      "i18n_getmessage(\"${1:message_name}\", ${2:substitutions})"
+      "i18n_getmessage('${1:message_name}', ${2:substitutions})"
     ],
     "description": "Gets the translated message for the language of the rendered page. Currently works only within modules.\nParameters:\n- message_name(String) The name of the message to look up\n- substitutions(sequence of strings) numbered substitution values used in placeholder 'content' attributes",
     "prefix": "~i18n_getmessage"
   },
   "include_css": {
     "body": [
-      "include_css(\"${1:path}\")"
+      "include_css('${1:path}')"
     ],
     "description": "Generates stylesheet link tag for specified template path\nParameters:\n- path(String) The Design Manager file path to the template or file",
     "prefix": "~include_css"
   },
   "include_javascript": {
     "body": [
-      "include_javascript(\"${1:path}\")"
+      "include_javascript('${1:path}')"
     ],
     "description": "Generates script include tag for specified template path\nParameters:\n- path(String) ",
     "prefix": "~include_javascript"
@@ -316,14 +330,14 @@
   },
   "module_asset_url": {
     "body": [
-      "module_asset_url(\"${1:name}\")"
+      "module_asset_url('${1:name}')"
     ],
     "description": "Gets the URL for an asset attached to a module\nParameters:\n- name(String) The name of the asset",
     "prefix": "~module_asset_url"
   },
   "oembed": {
     "body": [
-      "oembed(\"${1:request}\")"
+      "oembed('${1:request}')"
     ],
     "description": "Returns OEmbed data dictionary for given request. Only works in emails.\nParameters:\n- request(String) Request object, {url: string, max_width: long, max_height: long}",
     "prefix": "~oembed"
@@ -358,14 +372,14 @@
   },
   "require_css": {
     "body": [
-      "require_css(\"${1:url}\")"
+      "require_css('${1:url}')"
     ],
     "description": "Loads a css file to be output in the head\nParameters:\n- url(String) ",
     "prefix": "~require_css"
   },
   "require_js": {
     "body": [
-      "require_js(\"${1:url}\", \"${2:position}\")"
+      "require_js('${1:url}', '${2:position}')"
     ],
     "description": "Enqueues a js file to be output in the head or footer\nParameters:\n- url(String) \n- position(String) ",
     "prefix": "~require_js"
@@ -379,7 +393,7 @@
   },
   "script_embed": {
     "body": [
-      "script_embed(\"${1:type}\", \"${2:src}\", \"${3:title}\", \"${4:options}\", \"${5:description}\")"
+      "script_embed('${1:type}', '${2:src}', '${3:title}', '${4:options}', '${5:description}')"
     ],
     "description": "Defines an embeddable object which renders differently in the editor vs a live page\nParameters:\n- type(String) Type of embeddable object (wistia|embedly)\n- src(String) Object source\n- title(String) Object title\n- options(String) Options for particular type of embed\n- description(String) Description of embed for SEO purposes",
     "prefix": "~script_embed"
@@ -428,7 +442,7 @@
   },
   "truncate": {
     "body": [
-      "truncate(\"${1:s}\", ${2:length}, \"${3:end}\")"
+      "truncate('${1:s}', ${2:length}, '${3:end}')"
     ],
     "description": "truncates a given string to a specified length\nParameters:\n- s(String) \n- length(number) \n- end(String) ",
     "prefix": "~truncate"
@@ -446,5 +460,19 @@
     ],
     "description": "gets the unix timestamp milliseconds value of a datetime\nParameters:\n- var(date) ",
     "prefix": "~unixtimestamp"
+  },
+  "video_metadata_by_player_id": {
+    "body": [
+      "video_metadata_by_player_id(${1:request})"
+    ],
+    "description": "Returns the metadata of a video by player id. Only works for videos files that allow embedding, sharing, and tracking.\nParameters:\n- request(id) Request object, {id: long, domain: string}. Id is required. Domain is optional and will override the default domain of the video share url.",
+    "prefix": "~video_metadata_by_player_id"
+  },
+  "video_thumbnail": {
+    "body": [
+      "video_thumbnail('${1:request}')"
+    ],
+    "description": "Rewrites the URL of an image in File Manager to a URL that will overlay a play button on request.\nParameters:\n- request(String) Request object, {url: string, width: integer, height: integer, color: string scale: double} Url has to be the url of a HubSpot-hosted image. One of height or width is required. Color (optional) is a hex color string. Scale (optional) is a number between 0.1 an 1, default scale is 0.5.",
+    "prefix": "~video_thumbnail"
   }
 }

--- a/snippets/auto_gen/hubl_tags.json
+++ b/snippets/auto_gen/hubl_tags.json
@@ -1,119 +1,119 @@
 {
   "block": {
     "body": [
-      "{% block \"my_block\" \n\tblock_name=\"${1:block_name}\"%}\n\n{% endblock %}"
+      "{% block 'my_block' \n\tblock_name='${1:block_name}'%}\n\n{% endblock %}"
     ],
     "description": "Blocks are regions in a template which can be overridden by child templates\nParameters:\n- block_name(String) A unique name for the block that should be used in both the parent and child template",
     "prefix": "~block"
   },
   "blog_comments": {
     "body": [
-      "{% blog_comments \"my_blog_comments\" \n\tselect_blog=\"${1:select_blog}\", \n\tlimit=\"${2:limit}\", \n\tskip_css=\"${3:skip_css}\"%}"
+      "{% blog_comments 'my_blog_comments' \n\tselect_blog='${1:select_blog}', \n\tlimit='${2:limit}', \n\tskip_css='${3:skip_css}'%}"
     ],
     "description": "Renders the blog comments embed tag\nParameters:\n- select_blog('default' or blog id) Species which blog is connected to the comments embed\n- limit(number) Sets maximum number of comments\n- skip_css(bool) ",
     "prefix": "~blog_comments"
   },
   "blog_social_sharing": {
     "body": [
-      "{% blog_social_sharing \"my_blog_social_sharing\" \n\tselect_blog=\"${1:select_blog}\", \n\tdowngrade_shared_url=\"${2:downgrade_shared_url}\"%}"
+      "{% blog_social_sharing 'my_blog_social_sharing' \n\tselect_blog='${1:select_blog}', \n\tdowngrade_shared_url='${2:downgrade_shared_url}'%}"
     ],
     "description": "Blog social sharing module\nParameters:\n- select_blog('default' or blog id) Species which blog is connected to the share counters\n- downgrade_shared_url(boolean) Use http in the url sent to the social media networks. Used to preserve counts when upgrading domains to https only.",
     "prefix": "~blog_social_sharing"
   },
   "blog_subscribe": {
     "body": [
-      "{% blog_subscribe \"my_blog_subscribe\" \n\tselect_blog=\"${1:select_blog}\", \n\ttitle=\"${2:title}\", \n\tno_title=\"${3:no_title}\", \n\tresponse_message=\"${4:response_message}\", \n\tedit_form_link=\"${5:edit_form_link}\"%}"
+      "{% blog_subscribe 'my_blog_subscribe' \n\tselect_blog='${1:select_blog}', \n\ttitle='${2:title}', \n\tno_title='${3:no_title}', \n\tresponse_message='${4:response_message}', \n\tedit_form_link='${5:edit_form_link}'%}"
     ],
     "description": "Blog subscription module\nParameters:\n- select_blog('default' or blog id) Selects which blog subscription form to render\n- title(String) Defines text in an h3 tag title above the subscribe form\n- no_title(boolean)  If True, the h3 tag above the title is removed\n- response_message(String) Defines the inline thank-you message that is rendered when a user submits a form\n- edit_form_link(String) Generates a link that allows users to click through to the corresponding Form editor screen",
     "prefix": "~blog_subscribe"
   },
   "boolean": {
     "body": [
-      "{% boolean \"my_boolean\" \n\tvalue=\"${1:value}\"%}"
+      "{% boolean 'my_boolean' \n\tvalue='${1:value}'%}"
     ],
     "description": "A boolean option\nParameters:\n- value(boolean) Determines whether the checkbox is checked or unchecked",
     "prefix": "~boolean"
   },
   "call": {
     "body": [
-      "{% call \"my_call\" %}\n\n{% endcall %}"
+      "{% call 'my_call' %}\n\n{% endcall %}"
     ],
     "description": "In some cases it can be useful to pass a macro to another macro. For this purpose you can use the special call block.",
     "prefix": "~call"
   },
   "choice": {
     "body": [
-      "{% choice \"my_choice\" \n\tchoices=\"${1:choices}\", \n\tvalue=\"${2:value}\"%}"
+      "{% choice 'my_choice' \n\tchoices='${1:choices}', \n\tvalue='${2:value}'%}"
     ],
     "description": "A list of options\nParameters:\n- choices(String) Comma-separated list of values, or list of value-label pairs\n- value(String) The default field value for the dropdown",
     "prefix": "~choice"
   },
   "color": {
     "body": [
-      "{% color \"my_color\" \n\tcolor=\"${1:color}\"%}"
+      "{% color 'my_color' \n\tcolor='${1:color}'%}"
     ],
     "description": "A color picker module\nParameters:\n- color(String) A default HEX color value for the color picker module",
     "prefix": "~color"
   },
   "content_attribute": {
     "body": [
-      "{% content_attribute \"my_content_attribute\" %}\n\n{% end_content_attribute %}"
+      "{% content_attribute 'my_content_attribute' %}\n\n{% end_content_attribute %}"
     ],
     "description": "Sets default content in an attribute of the content object, such as content.email_body",
     "prefix": "~content_attribute"
   },
   "cta": {
     "body": [
-      "{% cta \"my_cta\" \n\tembed_code=\"${1:embed_code}\", \n\tfull_html=\"${2:full_html}\", \n\timage_src=\"${3:image_src}\", \n\timage_editor=\"${4:image_editor}\", \n\tguid=\"${5:guid}\", \n\timage_html=\"${6:image_html}\", \n\timage_email=\"${7:image_email}\"%}"
+      "{% cta 'my_cta' \n\tembed_code='${1:embed_code}', \n\tfull_html='${2:full_html}', \n\timage_src='${3:image_src}', \n\timage_editor='${4:image_editor}', \n\tguid='${5:guid}', \n\timage_html='${6:image_html}', \n\timage_email='${7:image_email}'%}"
     ],
     "description": "Renders a CTA module\nParameters:\n- embed_code(String) The embed code for the CTA\n- full_html(String) The embed code for the CTA. Same as embed_code\n- image_src(String) Image src url that defines the preview image in the content editor\n- image_editor(String) Markup for the image editor preview\n- guid(String) The unique ID number of the default CTA\n- image_html(String) CTA image HTML without the CTA script\n- image_email(String) Email-friendly version of the CTA code",
     "prefix": "~cta"
   },
   "custom_widget": {
     "body": [
-      "{% custom_widget \"my_custom_widget\" \n\twidget_definition=\"${1:widget_definition}\", \n\twidget_name=\"${2:widget_name}\"%}"
+      "{% custom_widget 'my_custom_widget' \n\twidget_definition='${1:widget_definition}', \n\twidget_name='${2:widget_name}'%}"
     ],
     "description": "A custom module\nParameters:\n- widget_definition(json object) \n- widget_name(String) Specifies the internal Design Manager name of the custom module that you would like to render",
     "prefix": "~custom_widget"
   },
   "cycle": {
     "body": [
-      "{% cycle \"my_cycle\" \n\tstring_to_print=\"${1:string_to_print}\"%}"
+      "{% cycle 'my_cycle' \n\tstring_to_print='${1:string_to_print}'%}"
     ],
     "description": "The cycle tag can be used within a for loop to cycle through a series of string values and print them with each iteration\nParameters:\n- string_to_print(String) A comma separated list of strings to print with each interation. The list will repeat if there are more iterations than string parameter values.",
     "prefix": "~cycle"
   },
   "dnd_area": {
     "body": [
-      "{% dnd_area \"my_dnd_area\" \n\tname=\"${1:name}\", \n\tlabel=\"${2:label}\", \n\tclass=\"${3:class}\"%}\n\n{% end_dnd_area %}"
+      "{% dnd_area 'my_dnd_area' \n\tname='${1:name}', \n\tlabel='${2:label}', \n\tclass='${3:class}'%}\n\n{% end_dnd_area %}"
     ],
     "description": "Creates container that supports drag-and-drop in content editors.\nParameters:\n- name(string) Identifier when storing data for a drag-and-drop area in the editors. Must be unique for all drag-and-drop areas in a template.\n- label(string) Label used in the editor for the drag-and-drop area.\n- class(string) Class names to add to the wrapping div.",
     "prefix": "~dnd_area"
   },
   "dnd_column": {
     "body": [
-      "{% dnd_column \"my_dnd_column\" \n\toffset=\"${1:offset}\", \n\twidth=\"${2:width}\", \n\tmargin=\"${3:margin}\", \n\tbackground_image=\"${4:background_image}\", \n\tbackground_color=\"${5:background_color}\"%}\n\n{% end_dnd_column %}"
+      "{% dnd_column 'my_dnd_column' \n\toffset='${1:offset}', \n\twidth='${2:width}', \n\tmargin='${3:margin}', \n\tbackground_image='${4:background_image}', \n\tbackground_color='${5:background_color}'%}\n\n{% end_dnd_column %}"
     ],
     "description": "A column inside a drag-and-drop area. Columns can only be children of a section or a row tag.\nParameters:\n- offset(integer) Number of rows to offset the module in the row (0-11).\n- width(integer) Number of rows wide the module should be.\n- margin(dict) Add top and bottom margin in pixels.\n- background_image(dict) Add a background image to the row.\n- background_color(dict) Specify a background color for the the row.",
     "prefix": "~dnd_column"
   },
   "dnd_module": {
     "body": [
-      "{% dnd_module \"my_dnd_module\" \n\tpath=\"${1:path}\", \n\toffset=\"${2:offset}\", \n\twidth=\"${3:width}\", \n\tflexbox_positioning=\"${4:flexbox_positioning}\"%}\n\n{% end_dnd_module %}"
+      "{% dnd_module 'my_dnd_module' \n\tpath='${1:path}', \n\toffset='${2:offset}', \n\twidth='${3:width}', \n\tflexbox_positioning='${4:flexbox_positioning}'%}\n\n{% end_dnd_module %}"
     ],
     "description": "Creates a wrapped module inside a drag-and-drop area.\nParameters:\n- path(string) Path to the module.\n- offset(integer) Number of rows to offset the module in the row (0-11).\n- width(integer) Number of rows wide the module should be.\n- flexbox_positioning(string) Adjust position of the module inside the row. Possible values are TOP_LEFT, TOP_CENTER, or TOP_RIGHT.",
     "prefix": "~dnd_module"
   },
   "dnd_row": {
     "body": [
-      "{% dnd_row \"my_dnd_row\" \n\tmargin=\"${1:margin}\", \n\tpadding=\"${2:padding}\", \n\tbackground_image=\"${3:background_image}\", \n\tbackground_color=\"${4:background_color}\"%}\n\n{% end_dnd_row %}"
+      "{% dnd_row 'my_dnd_row' \n\tmargin='${1:margin}', \n\tpadding='${2:padding}', \n\tbackground_image='${3:background_image}', \n\tbackground_color='${4:background_color}'%}\n\n{% end_dnd_row %}"
     ],
     "description": "A row inside a drag-and-drop area. Rows can only be children of columns.\nParameters:\n- margin(dict) Add top and bottom margin in pixels.\n- padding(dict) Add top, bottom, left, and right padding in pixels.\n- background_image(dict) Add a background image to the row.\n- background_color(dict) Specify a background color for the the row.",
     "prefix": "~dnd_row"
   },
   "dnd_section": {
     "body": [
-      "{% dnd_section \"my_dnd_section\" \n\tmax_width=\"${1:max_width}\", \n\tmargin=\"${2:margin}\", \n\tpadding=\"${3:padding}\", \n\tbackground_image=\"${4:background_image}\", \n\tbackground_color=\"${5:background_color}\"%}\n\n{% end_dnd_section %}"
+      "{% dnd_section 'my_dnd_section' \n\tmax_width='${1:max_width}', \n\tmargin='${2:margin}', \n\tpadding='${3:padding}', \n\tbackground_image='${4:background_image}', \n\tbackground_color='${5:background_color}'%}\n\n{% end_dnd_section %}"
     ],
     "description": "A top-level row inside a drag-and-drop area. Sections can only be children of a drag-and-drop area tag.\nParameters:\n- max_width(number) Maximum width of the section.\n- margin(dict) Add top and bottom margin in pixels.\n- padding(dict) Add top, bottom, left, and right padding in pixels.\n- background_image(dict) Add a background image to the row.\n- background_color(dict) Specify a background color for the the row.",
     "prefix": "~dnd_section"
@@ -127,42 +127,42 @@
   },
   "email_each": {
     "body": [
-      "{% email_each \"my_email_each\" \n\tlist=\"${1:list}\", \n\titem=\"${2:item}\"%}\n\n{% endemail_each %}"
+      "{% email_each 'my_email_each' \n\tlist='${1:list}', \n\titem='${2:item}'%}\n\n{% endemail_each %}"
     ],
     "description": "Allows looping over a list value in an email where a for loop would not work. Use \"item.\" to access the current element of the list.\nParameters:\n- list(String) \n- item(String) ",
     "prefix": "~email_each"
   },
   "email_flex_area": {
     "body": [
-      "{% email_flex_area \"my_email_flex_area\" \n\tname=\"${1:name}\", \n\tno_wrapper=\"${2:no_wrapper}\", \n\textra_classes=\"${3:extra_classes}\"%}"
+      "{% email_flex_area 'my_email_flex_area' \n\tname='${1:name}', \n\tno_wrapper='${2:no_wrapper}', \n\textra_classes='${3:extra_classes}'%}"
     ],
     "description": "An email flexible area tag is a widget container which renders its contained widgets in a box grid, \nwith an email friendly table-based layout.\n\nThe layout schema is defined in a JSON structure at the content level; these tags are always empty\nin their declaring templates.\nParameters:\n- name(String) \n- no_wrapper(boolean) \n- extra_classes(String) ",
     "prefix": "~email_flex_area"
   },
   "email_simple_subscription": {
     "body": [
-      "{% email_simple_subscription \"my_email_simple_subscription\" \n\theader=\"${1:header}\", \n\tinput_help_text=\"${2:input_help_text}\", \n\tbutton_text=\"${3:button_text}\", \n\tinput_placeholder=\"${4:input_placeholder}\"%}"
+      "{% email_simple_subscription 'my_email_simple_subscription' \n\theader='${1:header}', \n\tinput_help_text='${2:input_help_text}', \n\tbutton_text='${3:button_text}', \n\tinput_placeholder='${4:input_placeholder}'%}"
     ],
     "description": "Simple email unsubscribe form\nParameters:\n- header(String) Renders text in an h1 tag above the unsubscribe form\n- input_help_text(String) Renders help text in an h3 tag above your email unsubscribe form field\n- button_text(String) Changes the text of the unsubscribe form submit button\n- input_placeholder(String) Adds placeholder text within the email address form field",
     "prefix": "~email_simple_subscription"
   },
   "email_subscriptions": {
     "body": [
-      "{% email_subscriptions \"my_email_subscriptions\" \n\theader=\"${1:header}\", \n\tsubheader_text=\"${2:subheader_text}\", \n\tunsubscribe_single_text=\"${3:unsubscribe_single_text}\", \n\tunsubscribe_all_text=\"${4:unsubscribe_all_text}\", \n\tunsubscribe_all_unsubbed_text=\"${5:unsubscribe_all_unsubbed_text}\", \n\tunsubscribe_all_option=\"${6:unsubscribe_all_option}\", \n\tbutton_text=\"${7:button_text}\", \n\tresubscribe_button_text=\"${8:resubscribe_button_text}\"%}"
+      "{% email_subscriptions 'my_email_subscriptions' \n\theader='${1:header}', \n\tsubheader_text='${2:subheader_text}', \n\tunsubscribe_single_text='${3:unsubscribe_single_text}', \n\tunsubscribe_all_text='${4:unsubscribe_all_text}', \n\tunsubscribe_all_unsubbed_text='${5:unsubscribe_all_unsubbed_text}', \n\tunsubscribe_all_option='${6:unsubscribe_all_option}', \n\tbutton_text='${7:button_text}', \n\tresubscribe_button_text='${8:resubscribe_button_text}'%}"
     ],
     "description": "Email subscription preferences form\nParameters:\n- header(String) Renders text in an h1 tag above the subscription preferences form\n- subheader_text(String) Populates text below the heading above the unsubscribe preferences\n- unsubscribe_single_text(String) Renders text in a <p class=\"header\"> above the subscription options\n- unsubscribe_all_text(String) Renders text in a <p class=\"header\"> above the unsubscribe from all emails checkbox input\n- unsubscribe_all_unsubbed_text(String) Populates text within a <p> that renders, if a contact is currently unsubscribed from all emails\n- unsubscribe_all_option(String) Sets the text next to the unsubscribe from all emails checkbox input\n- button_text(String) Sets the text of the submit button that updates subscription preferences\n- resubscribe_button_text(String) Sets the text of the submit button for when contacts are resubscribing",
     "prefix": "~email_subscriptions"
   },
   "email_subscriptions_confirmation": {
     "body": [
-      "{% email_subscriptions_confirmation \"my_email_subscriptions_confirmation\" \n\theader=\"${1:header}\", \n\tsubheader_text=\"${2:subheader_text}\", \n\tunsubscribe_all_success=\"${3:unsubscribe_all_success}\", \n\tsubscription_update_success=\"${4:subscription_update_success}\"%}"
+      "{% email_subscriptions_confirmation 'my_email_subscriptions_confirmation' \n\theader='${1:header}', \n\tsubheader_text='${2:subheader_text}', \n\tunsubscribe_all_success='${3:unsubscribe_all_success}', \n\tsubscription_update_success='${4:subscription_update_success}'%}"
     ],
     "description": "Email unsubscribe form\nParameters:\n- header(String) Renders text in an h1 tag above the unsubscribe form\n- subheader_text(String) Populates text above the confirmation message\n- unsubscribe_all_success(String) Sets the text that will display when someone unsubscribes from all email communications\n- subscription_update_success(String) Sets the text when a recipient updates his or her subscription preferences",
     "prefix": "~email_subscriptions_confirmation"
   },
   "extends": {
     "body": [
-      "{% extends \"my_extends\" \n\tpath=\"${1:path}\"%}"
+      "{% extends 'my_extends' \n\tpath='${1:path}'%}"
     ],
     "description": "Template inheritance allows you to build a base “skeleton” template that contains all the common elements of your site and defines blocks that child templates can override.\nParameters:\n- path(String) Design Manager file path to parent template",
     "prefix": "~extends"
@@ -176,7 +176,7 @@
   },
   "follow_me": {
     "body": [
-      "{% follow_me \"my_follow_me\" \n\ttitle=\"${1:title}\", \n\tmodule_title_tag=\"${2:module_title_tag}\"%}"
+      "{% follow_me 'my_follow_me' \n\ttitle='${1:title}', \n\tmodule_title_tag='${2:module_title_tag}'%}"
     ],
     "description": "Deprecated: Use follow me default module instead.\nParameters:\n- title(String) Prints an h3 heading tag above the follow me module\n- module_title_tag(String) Specifies a heading tag h1-h6 to use for the module title",
     "prefix": "~follow_me"
@@ -190,7 +190,7 @@
   },
   "form": {
     "body": [
-      "{% form \"my_form\" \n\tform_key=\"${1:form_key}\", \n\tform_to_use=\"${2:form_to_use}\", \n\ttitle=\"${3:title}\", \n\tno_title=\"${4:no_title}\", \n\tform_follow_ups_follow_up_type=\"${5:form_follow_ups_follow_up_type}\", \n\tsimple_email_for_live_id=\"${6:simple_email_for_live_id}\", \n\tsimple_email_for_buffer_id=\"${7:simple_email_for_buffer_id}\", \n\tfollow_up_type_simple=\"${8:follow_up_type_simple}\", \n\tfollow_up_type_automation=\"${9:follow_up_type_automation}\", \n\tsimple_email_campaign_id=\"${10:simple_email_campaign_id}\", \n\tform_follow_ups_workflow_id=\"${11:form_follow_ups_workflow_id}\", \n\tresponse_redirect_url=\"${12:response_redirect_url}\", \n\tresponse_redirect_id=\"${13:response_redirect_id}\", \n\tresponse_response_type=\"${14:response_response_type}\", \n\tresponse_message=\"${15:response_message}\", \n\tnotifications_are_overridden=\"${16:notifications_are_overridden}\", \n\tnotifications_override_guid_buffer=\"${17:notifications_override_guid_buffer}\", \n\tnotifications_override_guid=\"${18:notifications_override_guid}\", \n\tnotifications_override_email_addresses=\"${19:notifications_override_email_addresses}\", \n\tgotowebinar_webinar_key=\"${20:gotowebinar_webinar_key}\", \n\tsfdc_campaign=\"${21:sfdc_campaign}\"%}"
+      "{% form 'my_form' \n\tform_key='${1:form_key}', \n\tform_to_use='${2:form_to_use}', \n\ttitle='${3:title}', \n\tno_title='${4:no_title}', \n\tform_follow_ups_follow_up_type='${5:form_follow_ups_follow_up_type}', \n\tsimple_email_for_live_id='${6:simple_email_for_live_id}', \n\tsimple_email_for_buffer_id='${7:simple_email_for_buffer_id}', \n\tfollow_up_type_simple='${8:follow_up_type_simple}', \n\tfollow_up_type_automation='${9:follow_up_type_automation}', \n\tsimple_email_campaign_id='${10:simple_email_campaign_id}', \n\tform_follow_ups_workflow_id='${11:form_follow_ups_workflow_id}', \n\tresponse_redirect_url='${12:response_redirect_url}', \n\tresponse_redirect_id='${13:response_redirect_id}', \n\tresponse_response_type='${14:response_response_type}', \n\tresponse_message='${15:response_message}', \n\tnotifications_are_overridden='${16:notifications_are_overridden}', \n\tnotifications_override_guid_buffer='${17:notifications_override_guid_buffer}', \n\tnotifications_override_guid='${18:notifications_override_guid}', \n\tnotifications_override_email_addresses='${19:notifications_override_email_addresses}', \n\tgotowebinar_webinar_key='${20:gotowebinar_webinar_key}', \n\tsfdc_campaign='${21:sfdc_campaign}'%}"
     ],
     "description": "Insert one of the forms created in the Form Manager\nParameters:\n- form_key(String) A unique id to target this form instance on the page\n- form_to_use(String) The form ID of the form to render by default\n- title(String) Populates an h3 header tag above the form\n- no_title(boolean) If True, the h3 tag above the title is removed.\n- form_follow_ups_follow_up_type(enum no_action|simple|automation) Specifies follow up action\n- simple_email_for_live_id(number) Specifies the ID of the simple follow-up email for the live page\n- simple_email_for_buffer_id(number) Specifies the ID of the simple follow-up email for the auto-save version of a page\n- follow_up_type_simple(boolean) If true, enables a simple follow-up email\n- follow_up_type_automation(boolean) If true, enrolls submissions in a workflow\n- simple_email_campaign_id(number) Specifies the ID of the simple follow-up email\n- form_follow_ups_workflow_id(number) Specifies the ID of the follow-up workflow\n- response_redirect_url(String) If redirecting to an external page, this parameter specifies the URL to redirect to\n- response_redirect_id(number) If redirecting to HubSpot hosted page, this parameter specifies the page ID of that page\n- response_response_type(enum inline|redirect) Determines whether to redirect to another page or to display an inline thank you message on submission\n- response_message(String) Sets an inline thank you message\n- notifications_are_overridden(boolean) If True, the form will send notifications to specified addresses selected in the notifications_override_email_addresses\n- notifications_override_guid_buffer(String) ID of override settings in auto-save version of page\n- notifications_override_guid(String) ID of override settings in live version of page\n- notifications_override_email_addresses(JSON list) These email addresses will override  the email notification settings set in the form\n- gotowebinar_webinar_key(String) Specifies the GoToWebinar webinar to enroll contacts who submit the form into\n- sfdc_campaign(String) Specifies the Salesforce campaign to enroll contacts who submit the form into",
     "prefix": "~form"
@@ -204,42 +204,42 @@
   },
   "gallery": {
     "body": [
-      "{% gallery \"my_gallery\" \n\tslides=\"${1:slides}\", \n\tloop_slides=\"${2:loop_slides}\", \n\tnum_seconds=\"${3:num_seconds}\", \n\tshow_pagination=\"${4:show_pagination}\", \n\tsizing=\"${5:sizing}\", \n\tauto_advance=\"${6:auto_advance}\", \n\ttransition=\"${7:transition}\", \n\tcaption_position=\"${8:caption_position}\", \n\tdisplay_mode=\"${9:display_mode}\", \n\tlightboxRows=\"${10:lightboxRows}\"%}"
+      "{% gallery 'my_gallery' \n\tslides='${1:slides}', \n\tloop_slides='${2:loop_slides}', \n\tnum_seconds='${3:num_seconds}', \n\tshow_pagination='${4:show_pagination}', \n\tsizing='${5:sizing}', \n\tauto_advance='${6:auto_advance}', \n\ttransition='${7:transition}', \n\tcaption_position='${8:caption_position}', \n\tdisplay_mode='${9:display_mode}', \n\tlightboxRows='${10:lightboxRows}'%}"
     ],
     "description": "Gallery\nParameters:\n- slides(json list) A JSON list of the default caption, the link url, the alt text, the image src, and whether to open in a new tab\n- loop_slides(boolean) When True, continuously loop through slides\n- num_seconds(number) Time in seconds to pause between slides\n- show_pagination(boolean) Provide buttons below slider to randomly navigate among slides\n- sizing(enum static|resize) Determines whether the slider changes sizes, based on the height of the slides\n- auto_advance(boolean) Automatically advance slides after the time set in num_seconds\n- transition(enum slide|) Sets the type of slide transition\n- caption_position(enum below|superimpose) Affects positioning of caption on or below the slide\n- display_mode(enum standard|thumbnail|lightbox) Determines which mode the slider will display\n- lightboxRows(number) Rows in lightbox mode",
     "prefix": "~gallery"
   },
   "global_module": {
     "body": [
-      "{% global_module \"my_global_module\" %}"
+      "{% global_module 'my_global_module' %}"
     ],
     "description": "",
     "prefix": "~global_module"
   },
   "global_widget": {
     "body": [
-      "{% global_widget \"my_global_widget\" \n\tglobal_widget_name=\"${1:global_widget_name}\"%}"
+      "{% global_widget 'my_global_widget' \n\tglobal_widget_name='${1:global_widget_name}'%}"
     ],
     "description": "A global widget is one which can be shared across templates\nParameters:\n- global_widget_name(String) Global module name",
     "prefix": "~global_widget"
   },
   "google_search": {
     "body": [
-      "{% google_search \"my_google_search\" \n\tprefill_input_with_pathname=\"${1:prefill_input_with_pathname}\", \n\tsearch_field_label=\"${2:search_field_label}\", \n\tsearch_button_text=\"${3:search_button_text}\"%}"
+      "{% google_search 'my_google_search' \n\tprefill_input_with_pathname='${1:prefill_input_with_pathname}', \n\tsearch_field_label='${2:search_field_label}', \n\tsearch_button_text='${3:search_button_text}'%}"
     ],
     "description": "Allow visitors to search your site on Google\nParameters:\n- prefill_input_with_pathname(boolean) Uses the end part of the URL to fill the search query field\n- search_field_label(String) Populates the label text in the <label> above the search input\n- search_button_text(String) Populates the text of the search submit button <a>",
     "prefix": "~google_search"
   },
   "header": {
     "body": [
-      "{% header \"my_header\" \n\theader_tag=\"${1:header_tag}\", \n\tvalue=\"${2:value}\"%}"
+      "{% header 'my_header' \n\theader_tag='${1:header_tag}', \n\tvalue='${2:value}'%}"
     ],
     "description": "One line of text to be displayed in a large font size\nParameters:\n- header_tag(String) Select which heading tag to render (h1-h6)\n- value(String) Renders default text within the heading module",
     "prefix": "~header"
   },
   "icon": {
     "body": [
-      "{% icon \"my_icon\" \n\tname=\"${1:name}\", \n\tset=\"${2:set}\", \n\tstyle=\"${3:style}\", \n\tformat=\"${4:format}\", \n\twidth=\"${5:width}\", \n\theight=\"${6:height}\", \n\tpurpose=\"${7:purpose}\", \n\ttitle=\"${8:title}\"%}"
+      "{% icon 'my_icon' \n\tname='${1:name}', \n\tset='${2:set}', \n\tstyle='${3:style}', \n\tformat='${4:format}', \n\twidth='${5:width}', \n\theight='${6:height}', \n\tpurpose='${7:purpose}', \n\ttitle='${8:title}'%}"
     ],
     "description": "Render an icon from the HubSpot icon library\nParameters:\n- name(String) The icon name\n- set(String) The icon set name. Currently defined sets: fontawesome-5 (see https://fontawesome.com/icons\n- style(String) The icon style. Regular, solid, or light\n- format(String) The output format. svg or unicode\n- width(String) The output image width. For svg format only\n- height(String) The output image height. For svg format only\n- purpose(String) The role of the icon in its context. Either 'semantic' or 'decorative'\n- title(String) A descriptive title for the icon",
     "prefix": "~icon"
@@ -253,21 +253,21 @@
   },
   "image": {
     "body": [
-      "{% image \"my_image\" \n\talt=\"${1:alt}\", \n\twidth=\"${2:width}\", \n\theight=\"${3:height}\", \n\talign=\"${4:align}\", \n\thspace=\"${5:hspace}\", \n\tstyle=\"${6:style}\", \n\tsrc=\"${7:src}\"%}"
+      "{% image 'my_image' \n\talt='${1:alt}', \n\twidth='${2:width}', \n\theight='${3:height}', \n\talign='${4:align}', \n\thspace='${5:hspace}', \n\tstyle='${6:style}', \n\tsrc='${7:src}'%}"
     ],
     "description": "Renders an image tag\nParameters:\n- alt(String) Sets the default alt text for the image\n- width(number) Sets the width attribute of the img tag\n- height(number) Sets a min-height in a style attribute of the img tag for email templates only\n- align(String) Sets the align attribute of the img tag (right, left, center)\n- hspace(number) Sets the hspace attribute of the img tag\n- style(String) Adds inline CSS declarations to the img tag\n- src(String) Populates the src attribute of the img tag",
     "prefix": "~image"
   },
   "image_slider": {
     "body": [
-      "{% image_slider \"my_image_slider\" \n\tslides=\"${1:slides}\", \n\tloop_slides=\"${2:loop_slides}\", \n\tnum_seconds=\"${3:num_seconds}\", \n\tshow_pagination=\"${4:show_pagination}\", \n\tsizing=\"${5:sizing}\", \n\tauto_advance=\"${6:auto_advance}\", \n\ttransition=\"${7:transition}\", \n\tcaption_position=\"${8:caption_position}\", \n\tlightbox=\"${9:lightbox}\", \n\tonly_thumbnails=\"${10:only_thumbnails}\", \n\twith_thumbnail_nav=\"${11:with_thumbnail_nav}\", \n\tdisplay_mode=\"${12:display_mode}\", \n\tversion=\"${13:version}\", \n\tlightboxRows=\"${14:lightboxRows}\"%}"
+      "{% image_slider 'my_image_slider' \n\tslides='${1:slides}', \n\tloop_slides='${2:loop_slides}', \n\tnum_seconds='${3:num_seconds}', \n\tshow_pagination='${4:show_pagination}', \n\tsizing='${5:sizing}', \n\tauto_advance='${6:auto_advance}', \n\ttransition='${7:transition}', \n\tcaption_position='${8:caption_position}', \n\tlightbox='${9:lightbox}', \n\tonly_thumbnails='${10:only_thumbnails}', \n\twith_thumbnail_nav='${11:with_thumbnail_nav}', \n\tdisplay_mode='${12:display_mode}', \n\tversion='${13:version}', \n\tlightboxRows='${14:lightboxRows}'%}"
     ],
     "description": "Image slider\nParameters:\n- slides(json list) A JSON list of the default caption, the link url, the alt text, the image src, and whether to open in a new tab\n- loop_slides(boolean) When True, continuously loop through slides\n- num_seconds(number) Time in seconds to pause between slides\n- show_pagination(boolean) Provide buttons below slider to randomly navigate among slides\n- sizing(enum static|resize) Determines whether the slider changes sizes, based on the height of the slides\n- auto_advance(boolean) Automatically advance slides after the time set in num_seconds\n- transition(enum slide|) Sets the type of slide transition\n- caption_position(enum below|superimpose) Affects positioning of caption on or below the slide\n- lightbox(boolean) Displays thumbnail image in lightbox, when clicked\n- only_thumbnails(boolean) Display images as thumbnails instead of a slider\n- with_thumbnail_nav(boolean) Include thumbnails below slider for navigation\n- display_mode(enum standard|thumbnail|lightbox) Determines which mode the slider will display\n- version(string) Gallery Version Number\n- lightboxRows(number) Rows in lightbox mode",
     "prefix": "~image_slider"
   },
   "image_src": {
     "body": [
-      "{% image_src \"my_image_src\" \n\tsrc=\"${1:src}\"%}"
+      "{% image_src 'my_image_src' \n\tsrc='${1:src}'%}"
     ],
     "description": "Prints the src attribute value of an image\nParameters:\n- src(String) Specifies the default URL image src",
     "prefix": "~image_src"
@@ -288,189 +288,189 @@
   },
   "inline_rich_text": {
     "body": [
-      "{% inline_rich_text \"my_inline_rich_text\" \n\tvalue=\"${1:value}\", \n\tfield=\"${2:field}\"%}"
+      "{% inline_rich_text 'my_inline_rich_text' \n\tvalue='${1:value}', \n\tfield='${2:field}'%}"
     ],
     "description": "A rich text area that can be edited inline inside modules\nParameters:\n- value(String) Sets the default content of the rich text module\n- field(String) Required name of the module field to which this text is associated",
     "prefix": "~inline_rich_text"
   },
   "inline_text": {
     "body": [
-      "{% inline_text \"my_inline_text\" \n\tvalue=\"${1:value}\", \n\tfield=\"${2:field}\"%}"
+      "{% inline_text 'my_inline_text' \n\tvalue='${1:value}', \n\tfield='${2:field}'%}"
     ],
     "description": "A single line of text with no formatting that can be edited inline inside modules\nParameters:\n- value(String) The default text of the single line text field\n- field(String) Required name of the module field to which this text is associated",
     "prefix": "~inline_text"
   },
   "language_switcher": {
     "body": [
-      "{% language_switcher \"my_language_switcher\" \n\tdisplay_mode=\"${1:display_mode}\"%}"
+      "{% language_switcher 'my_language_switcher' \n\tdisplay_mode='${1:display_mode}'%}"
     ],
     "description": "Language switcher\nParameters:\n- display_mode(enum localized|pagelang|hybrid) The language of the text in the language switcher. Pagelang means the names of languages will display in the language of the page the switcher is on. Localized means the name of each language will display in that language. Hybrid is a combination of the two.",
     "prefix": "~language_switcher"
   },
   "linked_image": {
     "body": [
-      "{% linked_image \"my_linked_image\" \n\topen_in_new_tab=\"${1:open_in_new_tab}\", \n\ttarget=\"${2:target}\", \n\tlink=\"${3:link}\", \n\talt=\"${4:alt}\", \n\twidth=\"${5:width}\", \n\theight=\"${6:height}\", \n\talign=\"${7:align}\", \n\thspace=\"${8:hspace}\", \n\tstyle=\"${9:style}\", \n\tsrc=\"${10:src}\"%}"
+      "{% linked_image 'my_linked_image' \n\topen_in_new_tab='${1:open_in_new_tab}', \n\ttarget='${2:target}', \n\tlink='${3:link}', \n\talt='${4:alt}', \n\twidth='${5:width}', \n\theight='${6:height}', \n\talign='${7:align}', \n\thspace='${8:hspace}', \n\tstyle='${9:style}', \n\tsrc='${10:src}'%}"
     ],
     "description": "Insert a linked image from File Manager.\nParameters:\n- open_in_new_tab(boolean) Selects whether or not to open the destination URL in another tab\n- target(String) Sets the target attr of link tag\n- link(String) Sets the destination URL of the link that wraps the img tag\n- alt(String) Sets the default alt text for the image\n- width(number) Sets the width attribute of the img tag\n- height(number) Sets a min-height in a style attribute of the img tag for email templates only\n- align(String) Sets the align attribute of the img tag (right, left, center)\n- hspace(number) Sets the hspace attribute of the img tag\n- style(String) Adds inline CSS declarations to the img tag\n- src(String) Populates the src attribute of the img tag",
     "prefix": "~linked_image"
   },
   "logo": {
     "body": [
-      "{% logo \"my_logo\" \n\tsuppress_company_name=\"${1:suppress_company_name}\", \n\toverride_inherited_src=\"${2:override_inherited_src}\", \n\tsrc=\"${3:src}\", \n\talt=\"${4:alt}\", \n\tlink=\"${5:link}\", \n\twidth=\"${6:width}\", \n\theight=\"${7:height}\", \n\talign=\"${8:align}\", \n\thspace=\"${9:hspace}\", \n\tstyle=\"${10:style}\", \n\topen_in_new_tab=\"${11:open_in_new_tab}\", \n\theading_style=\"${12:heading_style}\"%}"
+      "{% logo 'my_logo' \n\tsuppress_company_name='${1:suppress_company_name}', \n\toverride_inherited_src='${2:override_inherited_src}', \n\tsrc='${3:src}', \n\talt='${4:alt}', \n\tlink='${5:link}', \n\twidth='${6:width}', \n\theight='${7:height}', \n\talign='${8:align}', \n\thspace='${9:hspace}', \n\tstyle='${10:style}', \n\topen_in_new_tab='${11:open_in_new_tab}', \n\theading_style='${12:heading_style}'%}"
     ],
     "description": "Logo image\nParameters:\n- suppress_company_name(boolean) Hides company name if an image logo isn't set\n- override_inherited_src(boolean) If true, use src from logo widget rather than src inherited from settings or template.\n- src(String) Populates the src attribute of the img tag\n- alt(String) Sets the default alt text for the image\n- link(String) Sets the destination URL of the link that wraps the img tag\n- width(number) Sets the width attribute of the img tag\n- height(number) Sets a min-height in a style attribute of the img tag for email templates only\n- align(String) Sets the align attribute of the img tag (right, left, center)\n- hspace(number) Sets the hspace attribute of the img tag\n- style(String) Adds inline CSS declarations to the img tag\n- open_in_new_tab(boolean) Selects whether or not to open the destination URL in another tab\n- heading_style(String) Sets the link heading style. Can be one of h1, h2, h3, or h4",
     "prefix": "~logo"
   },
   "macro": {
     "body": [
-      "{% macro \"my_macro\" \n\tmacro_name=\"${1:macro_name}\", \n\targument_names=\"${2:argument_names}\"%}\n\n{% endmacro %}"
+      "{% macro 'my_macro' \n\tmacro_name='${1:macro_name}', \n\targument_names='${2:argument_names}'%}\n\n{% endmacro %}"
     ],
     "description": "Macros allow you to print multiple statements with a dynamic value or values\nParameters:\n- macro_name(String) The name given to a macro\n- argument_names(String) Named arguments that are dynamically, when the macro is run",
     "prefix": "~macro"
   },
   "member_login": {
     "body": [
-      "{% member_login \"my_member_login\" \n\temail_label=\"${1:email_label}\", \n\tpassword_label=\"${2:password_label}\", \n\tremember_me_label=\"${3:remember_me_label}\", \n\tsubmit_button_text=\"${4:submit_button_text}\", \n\treset_password_text=\"${5:reset_password_text}\", \n\treset_password_link=\"${6:reset_password_link}\", \n\tshow_password=\"${7:show_password}\"%}"
+      "{% member_login 'my_member_login' \n\temail_label='${1:email_label}', \n\tpassword_label='${2:password_label}', \n\tremember_me_label='${3:remember_me_label}', \n\tsubmit_button_text='${4:submit_button_text}', \n\treset_password_text='${5:reset_password_text}', \n\treset_password_link='${6:reset_password_link}', \n\tshow_password='${7:show_password}'%}"
     ],
     "description": "Render a login form.\nParameters:\n- email_label(String) Label for email input field\n- password_label(String) Label for password input field\n- remember_me_label(String) Label for Remember Me checkbox\n- submit_button_text(String) Label for form submit button\n- reset_password_text(String) Label for password reset link\n- reset_password_link(String) Link to password reset request page\n- show_password(String) Label for Show password buttons",
     "prefix": "~member_login"
   },
   "member_register": {
     "body": [
-      "{% member_register \"my_member_register\" \n\temail_label=\"${1:email_label}\", \n\tpassword_label=\"${2:password_label}\", \n\tpassword_confirm_label=\"${3:password_confirm_label}\", \n\tsubmit_button_text=\"${4:submit_button_text}\", \n\tshow_password=\"${5:show_password}\"%}"
+      "{% member_register 'my_member_register' \n\temail_label='${1:email_label}', \n\tpassword_label='${2:password_label}', \n\tpassword_confirm_label='${3:password_confirm_label}', \n\tsubmit_button_text='${4:submit_button_text}', \n\tshow_password='${5:show_password}'%}"
     ],
     "description": "Render a registration form.\nParameters:\n- email_label(String) Label for email input field\n- password_label(String) Label for password input field\n- password_confirm_label(String) Label for password confirm input field\n- submit_button_text(String) Label for form submit button\n- show_password(String) Label for Show password buttons",
     "prefix": "~member_register"
   },
   "menu": {
     "body": [
-      "{% menu \"my_menu\" \n\tflow=\"${1:flow}\", \n\troot_type=\"${2:root_type}\", \n\troot_key=\"${3:root_key}\", \n\tmax_levels=\"${4:max_levels}\", \n\tflyouts=\"${5:flyouts}\", \n\tsite_map_name=\"${6:site_map_name}\", \n\tid=\"${7:id}\"%}"
+      "{% menu 'my_menu' \n\tflow='${1:flow}', \n\troot_type='${2:root_type}', \n\troot_key='${3:root_key}', \n\tmax_levels='${4:max_levels}', \n\tflyouts='${5:flyouts}', \n\tsite_map_name='${6:site_map_name}', \n\tid='${7:id}'%}"
     ],
     "description": "Advanced menu module\nParameters:\n- flow(enum horizontal|vertical)  This adds classes to the menu tree so that they can be styled accordingly\n- root_type(enum site_root|top_parent|parent|page_id|page_name|breadcrumb) Specifies the type of advanced menu\n- root_key(String) Used to find the menu root. When root_type is set to page_id or page_name, this param should be the page ID or the label of the page, respectively\n- max_levels(number) Determines how many levels of nested menus render in the markup\n- flyouts(boolean) When true, a class is added to the menu tree that can be styled to allow child menu items will appear when you hover over the parent\n- site_map_name(String) Name of menu tree from Advanced Menus\n- id(String) The menu id from Advanced Menus",
     "prefix": "~menu"
   },
   "module": {
     "body": [
-      "{% module \"my_module\" \n\tmodule_id=\"${1:module_id}\", \n\tpath=\"${2:path}\"%}"
+      "{% module 'my_module' \n\tmodule_id='${1:module_id}', \n\tpath='${2:path}'%}"
     ],
     "description": "A module\nParameters:\n- module_id(String) The id of the module to render\n- path(String) The path of the module to render. Include leading slash for absolute path, otherwise path is relative to template. Reference HubSpot default modules with paths corresponding to their HubL tags such as @hubspot/rich_text, @hubspot/linked_image, etc.",
     "prefix": "~module"
   },
   "module_attribute": {
     "body": [
-      "{% module_attribute \"my_module_attribute\" %}\n\n{% end_module_block %}"
+      "{% module_attribute 'my_module_attribute' %}\n\n{% end_module_block %}"
     ],
     "description": "Defines a rich attribute for a module. Only valid within a module_block tag",
     "prefix": "~module_attribute"
   },
   "page_footer": {
     "body": [
-      "{% page_footer \"my_page_footer\" %}"
+      "{% page_footer 'my_page_footer' %}"
     ],
     "description": "Company copyright information footer",
     "prefix": "~page_footer"
   },
   "password_prompt": {
     "body": [
-      "{% password_prompt \"my_password_prompt\" \n\tsubmit_button_text=\"${1:submit_button_text}\", \n\tpassword_placeholder=\"${2:password_placeholder}\", \n\tbad_password_message=\"${3:bad_password_message}\"%}"
+      "{% password_prompt 'my_password_prompt' \n\tsubmit_button_text='${1:submit_button_text}', \n\tpassword_placeholder='${2:password_placeholder}', \n\tbad_password_message='${3:bad_password_message}'%}"
     ],
     "description": "Requests a password to access a landing page.\nParameters:\n- submit_button_text(String) Label for button below password entry field\n- password_placeholder(String) Placeholder text for the password field\n- bad_password_message(String) Text to display if an incorrect password is entered",
     "prefix": "~password_prompt"
   },
   "password_reset": {
     "body": [
-      "{% password_reset \"my_password_reset\" \n\tpassword_label=\"${1:password_label}\", \n\tpassword_confirm_label=\"${2:password_confirm_label}\", \n\tsubmit_button_text=\"${3:submit_button_text}\", \n\tshow_password=\"${4:show_password}\"%}"
+      "{% password_reset 'my_password_reset' \n\tpassword_label='${1:password_label}', \n\tpassword_confirm_label='${2:password_confirm_label}', \n\tsubmit_button_text='${3:submit_button_text}', \n\tshow_password='${4:show_password}'%}"
     ],
     "description": "Render a password reset form.\nParameters:\n- password_label(String) Label for password input field\n- password_confirm_label(String) Label from password confirm field\n- submit_button_text(String) Label for form submit button\n- show_password(String) Label for Show password buttons",
     "prefix": "~password_reset"
   },
   "password_reset_request": {
     "body": [
-      "{% password_reset_request \"my_password_reset_request\" \n\temail_label=\"${1:email_label}\", \n\tsubmit_button_text=\"${2:submit_button_text}\"%}"
+      "{% password_reset_request 'my_password_reset_request' \n\temail_label='${1:email_label}', \n\tsubmit_button_text='${2:submit_button_text}'%}"
     ],
     "description": "Render a password reset request form.\nParameters:\n- email_label(String) Label for email input field\n- submit_button_text(String) Label for form submit button",
     "prefix": "~password_reset_request"
   },
   "post_filter": {
     "body": [
-      "{% post_filter \"my_post_filter\" \n\tselect_blog=\"${1:select_blog}\", \n\texpand_link_text=\"${2:expand_link_text}\", \n\ttitle_tag=\"${3:title_tag}\", \n\tlist_tag=\"${4:list_tag}\", \n\tlist_title=\"${5:list_title}\", \n\tmax_links=\"${6:max_links}\", \n\tfilter_type=\"${7:filter_type}\"%}"
+      "{% post_filter 'my_post_filter' \n\tselect_blog='${1:select_blog}', \n\texpand_link_text='${2:expand_link_text}', \n\ttitle_tag='${3:title_tag}', \n\tlist_tag='${4:list_tag}', \n\tlist_title='${5:list_title}', \n\tmax_links='${6:max_links}', \n\tfilter_type='${7:filter_type}'%}"
     ],
     "description": "Include a list of links to filter blog posts. Filter posts by tag, month, or author. \nThis module can only be used in templates for: Blog Post\nParameters:\n- select_blog('default' or blog id) Selects the HubSpot blog to use for the listing\n- expand_link_text(String) Text link to display if more posts than max_links number available\n- title_tag(String) Sets the tag used for the list title \n- list_tag(String) Sets the tag used for the list\n- list_title(String) List title to display\n- max_links(number) Sets maximum number of links\n- filter_type(enum author|month|tag) Selects the type of filter",
     "prefix": "~post_filter"
   },
   "post_listing": {
     "body": [
-      "{% post_listing \"my_post_listing\" \n\tselect_blog=\"${1:select_blog}\", \n\ttitle_tag=\"${2:title_tag}\", \n\tlist_tag=\"${3:list_tag}\", \n\tlist_title=\"${4:list_title}\", \n\tinclude_featured_image=\"${5:include_featured_image}\", \n\tlisting_type=\"${6:listing_type}\", \n\tmax_links=\"${7:max_links}\"%}"
+      "{% post_listing 'my_post_listing' \n\tselect_blog='${1:select_blog}', \n\ttitle_tag='${2:title_tag}', \n\tlist_tag='${3:list_tag}', \n\tlist_title='${4:list_title}', \n\tinclude_featured_image='${5:include_featured_image}', \n\tlisting_type='${6:listing_type}', \n\tmax_links='${7:max_links}'%}"
     ],
-    "description": "Include a listing of links to blog posts. Order posts by date or popularity.\nThis module can only be used in templates for: Blog Post\nParameters:\n- select_blog('default' or blog id) Selects the HubSpot blog to use for the listing\n- title_tag(String) Sets the tag used for the list title\n- list_tag(String) Sets the tag used for the list\n- list_title(String) List title to display\n- include_featured_image(boolean) Display featured image along with post link\n- listing_type(enum recent|popular_all_time|popular_past_year|popular_past_six_months|popular_past_month|recommended) Selects the type of listing to render\n- max_links(number) Sets maximum number of links",
+    "description": "Include a listing of links to blog posts. Order posts by date or popularity.\nThis module can only be used in templates for: Blog Post\nParameters:\n- select_blog('default' or blog id) Selects the HubSpot blog to use for the listing\n- title_tag(String) Sets the tag used for the list title\n- list_tag(String) Sets the tag used for the list\n- list_title(String) List title to display\n- include_featured_image(boolean) Display featured image along with post link\n- listing_type(enum recent|popular_all_time|popular_past_year|popular_past_six_months|popular_past_month) Selects the type of listing to render\n- max_links(number) Sets maximum number of links",
     "prefix": "~post_listing"
   },
   "print": {
     "body": [
-      "{% print \"my_print\" \n\texpr=\"${1:expr}\"%}"
+      "{% print 'my_print' \n\texpr='${1:expr}'%}"
     ],
     "description": "Echos the result of the expression\nParameters:\n- expr(expression) Expression to print",
     "prefix": "~print"
   },
   "raw": {
     "body": [
-      "{% raw \"my_raw\" %}\n\n{% endraw %}"
+      "{% raw 'my_raw' %}\n\n{% endraw %}"
     ],
     "description": "Process all inner expressions as plain text",
     "prefix": "~raw"
   },
   "raw_html": {
     "body": [
-      "{% raw_html \"my_raw_html\" \n\tvalue=\"${1:value}\"%}"
+      "{% raw_html 'my_raw_html' \n\tvalue='${1:value}'%}"
     ],
     "description": "Insert custom HTML module\nParameters:\n- value(String) Sets the default content HTML of the module",
     "prefix": "~raw_html"
   },
   "related_blog_posts": {
     "body": [
-      "{% related_blog_posts \"my_related_blog_posts\" \n\tblog_ids=\"${1:blog_ids}\", \n\tblog_post_ids=\"${2:blog_post_ids}\", \n\tblog_post_override=\"${3:blog_post_override}\", \n\tlimit=\"${4:limit}\", \n\ttags=\"${5:tags}\", \n\tstart_date=\"${6:start_date}\", \n\tend_date=\"${7:end_date}\", \n\tblog_authors=\"${8:blog_authors}\", \n\tpath_prefixes=\"${9:path_prefixes}\", \n\tpost_formatter=\"${10:post_formatter}\"%}"
+      "{% related_blog_posts 'my_related_blog_posts' \n\tblog_ids='${1:blog_ids}', \n\tblog_post_ids='${2:blog_post_ids}', \n\tblog_post_override='${3:blog_post_override}', \n\tlimit='${4:limit}', \n\ttags='${5:tags}', \n\tstart_date='${6:start_date}', \n\tend_date='${7:end_date}', \n\tblog_authors='${8:blog_authors}', \n\tpath_prefixes='${9:path_prefixes}', \n\tpost_formatter='${10:post_formatter}'%}"
     ],
     "description": "Returns a list of related blog post objects for the specified blog, sorted by relevance for the given parameters\nParameters:\n- blog_ids(comma separated blog ids) Limit results to these blog(s)\n- blog_post_ids(comma separated blog post ids) Blog posts to use in similarity search\n- blog_post_override(comma separated blog post ids) Blog posts that must be included in results\n- limit(number) Max number of posts to return\n- tags(comma separated tag names) The tag name(s) to filter with\n- start_date(date (yyyy-mm-dd)) Earliest published date\n- end_date(date (yyyy-mm-dd)) Latest published date\n- blog_authors(comma separated blog author names) Limit results to these author name(s)\n- path_prefixes(comma separated path prefixes) The path prefixes\n- post_formatter(string) Name of macro to render a blog post",
     "prefix": "~related_blog_posts"
   },
   "require_css": {
     "body": [
-      "{% require_css \"my_require_css\" %}"
+      "{% require_css 'my_require_css' %}"
     ],
     "description": "Enqueue an inline stylesheet",
     "prefix": "~require_css"
   },
   "require_head": {
     "body": [
-      "{% require_head \"my_require_head\" %}"
+      "{% require_head 'my_require_head' %}"
     ],
     "description": "Enqueue a head element",
     "prefix": "~require_head"
   },
   "require_js": {
     "body": [
-      "{% require_js \"my_require_js\" \n\tposition=\"${1:position}\"%}"
+      "{% require_js 'my_require_js' \n\tposition='${1:position}'%}"
     ],
     "description": "Enqueue an inline script\nParameters:\n- position(String) ",
     "prefix": "~require_js"
   },
   "rich_text": {
     "body": [
-      "{% rich_text \"my_rich_text\" \n\thtml=\"${1:html}\"%}"
+      "{% rich_text 'my_rich_text' \n\thtml='${1:html}'%}"
     ],
     "description": "A block of text and content that can be styled with the editor.\nParameters:\n- html(String) Sets the default content of the rich text module",
     "prefix": "~rich_text"
   },
   "rss_listing": {
     "body": [
-      "{% rss_listing \"my_rss_listing\" \n\tshow_title=\"${1:show_title}\", \n\tshow_date=\"${2:show_date}\", \n\tshow_author=\"${3:show_author}\", \n\tshow_detail=\"${4:show_detail}\", \n\ttitle=\"${5:title}\", \n\tlimit_to_chars=\"${6:limit_to_chars}\", \n\tpublish_date_format=\"${7:publish_date_format}\", \n\tattribution_text=\"${8:attribution_text}\", \n\tclick_through_text=\"${9:click_through_text}\", \n\tpublish_date_text=\"${10:publish_date_text}\", \n\tinclude_featured_image=\"${11:include_featured_image}\", \n\titem_title_tag=\"${12:item_title_tag}\", \n\tis_external=\"${13:is_external}\", \n\tnumber_of_items=\"${14:number_of_items}\", \n\tpublish_date_language=\"${15:publish_date_language}\", \n\trss_url=\"${16:rss_url}\", \n\tcontent_group_id=\"${17:content_group_id}\", \n\ttag_id=\"${18:tag_id}\", \n\tselect_blog=\"${19:select_blog}\", \n\tfeed_source=\"${20:feed_source}\"%}"
+      "{% rss_listing 'my_rss_listing' \n\tshow_title='${1:show_title}', \n\tshow_date='${2:show_date}', \n\tshow_author='${3:show_author}', \n\tshow_detail='${4:show_detail}', \n\ttitle='${5:title}', \n\tlimit_to_chars='${6:limit_to_chars}', \n\tpublish_date_format='${7:publish_date_format}', \n\tattribution_text='${8:attribution_text}', \n\tclick_through_text='${9:click_through_text}', \n\tpublish_date_text='${10:publish_date_text}', \n\tinclude_featured_image='${11:include_featured_image}', \n\titem_title_tag='${12:item_title_tag}', \n\tis_external='${13:is_external}', \n\tnumber_of_items='${14:number_of_items}', \n\tpublish_date_language='${15:publish_date_language}', \n\trss_url='${16:rss_url}', \n\tcontent_group_id='${17:content_group_id}', \n\ttag_id='${18:tag_id}', \n\tselect_blog='${19:select_blog}', \n\tfeed_source='${20:feed_source}'%}"
     ],
     "description": "RSS Listing\nParameters:\n- show_title(boolean) Shows or hides RSS feed title\n- show_date(boolean) Displays post date\n- show_author(boolean) Displays author name\n- show_detail(boolean) Display post summary up to number of characters set by limit_to_chars parameter\n- title(String) Populates a heading above the RSS feed listing\n- limit_to_chars(number) Maximum number of characters to display in summary\n- publish_date_format(String)  Format for the publish date. Possible values include 'short', 'medium', 'long', or custom (MMMM d, yyyy)\n- attribution_text(String) The text which attributes an author to a post\n- click_through_text(String) The text which will be displayed for the click through link at the end of a post summary\n- publish_date_text(String) The text which indicates when a post was published\n- include_featured_image(boolean) Displays featured image with post link for HubSpot generated RSS feeds\n- item_title_tag(String) Specifies HTML tag of each post title\n- is_external(boolean) RSS feed is from an external blog\n- number_of_items(number) Maximum number of posts to display\n- publish_date_language(String) Specifies the language of the publish date (for external feeds)\n- rss_url(string) The URL where the RSS feed is located\n- content_group_id(number) ID for blog when feed source is internal blog\n- tag_id(number) ID for tag when feed source is internal blog\n- select_blog('default' or blog id) Can be used to select an internal HubSpot blog feed\n- feed_source(String) Set source for RSS feed (contains is_external, rss_url, and/or content_group_id",
     "prefix": "~rss_listing"
   },
   "section_header": {
     "body": [
-      "{% section_header \"my_section_header\" \n\theader=\"${1:header}\", \n\tsubheader=\"${2:subheader}\"%}"
+      "{% section_header 'my_section_header' \n\theader='${1:header}', \n\tsubheader='${2:subheader}'%}"
     ],
     "description": "An extra large, centered, header to denote an entire section\nParameters:\n- header(String) Text to display in header\n- subheader(String) Text to display in subheader",
     "prefix": "~section_header"
@@ -484,98 +484,98 @@
   },
   "simple_menu": {
     "body": [
-      "{% simple_menu \"my_simple_menu\" \n\torientation=\"${1:orientation}\", \n\tmenu_tree=\"${2:menu_tree}\"%}"
+      "{% simple_menu 'my_simple_menu' \n\torientation='${1:orientation}', \n\tmenu_tree='${2:menu_tree}'%}"
     ],
     "description": "Simple menu, uses static link structure\nParameters:\n- orientation(enum horizontal|vertical) Defines classes of menu markup to allow to style the orientation of menu items on the page\n- menu_tree(json list) Menu structure including page link names and target URLs",
     "prefix": "~simple_menu"
   },
   "social_sharing": {
     "body": [
-      "{% social_sharing \"my_social_sharing\" \n\tuse_page_url=\"${1:use_page_url}\", \n\tlink=\"${2:link}\", \n\tpinterest=\"${3:pinterest}\", \n\ttwitter=\"${4:twitter}\", \n\tlinked_in=\"${5:linked_in}\", \n\tfacebook=\"${6:facebook}\", \n\temail=\"${7:email}\"%}"
+      "{% social_sharing 'my_social_sharing' \n\tuse_page_url='${1:use_page_url}', \n\tlink='${2:link}', \n\tpinterest='${3:pinterest}', \n\ttwitter='${4:twitter}', \n\tlinked_in='${5:linked_in}', \n\tfacebook='${6:facebook}', \n\temail='${7:email}'%}"
     ],
     "description": "Allow visitors to share your page on social networks\nParameters:\n- use_page_url(boolean) If true, the module shares the URL of the page by default\n- link(String) Specifies a different URL to share\n- pinterest(JSON) Parameters for Pinterest link format and icon image source\n- twitter(JSON) Parameters for Twitter link format and icon image source\n- linked_in(JSON) Parameters for LinkedIn link format and icon image source\n- facebook(JSON) Parameters for Facebook link format and icon image source\n- email(JSON) Parameters for email sharing link format and icon image source ",
     "prefix": "~social_sharing"
   },
   "space": {
     "body": [
-      "{% space \"my_space\" %}"
+      "{% space 'my_space' %}"
     ],
     "description": "Used to add an empty module for spacing to the left or right of another module in a row",
     "prefix": "~space"
   },
   "style_settings": {
     "body": [
-      "{% style_settings \"my_style_settings\" %}"
+      "{% style_settings 'my_style_settings' %}"
     ],
     "description": "Provides style context from a template that will be used when a style is not defined on the content object",
     "prefix": "~style_settings"
   },
   "targeted_module_attribute": {
     "body": [
-      "{% targeted_module_attribute \"my_targeted_module_attribute\" \n\tcriterion_id=\"${1:criterion_id}\", \n\torder=\"${2:order}\", \n\ttarget_type=\"${3:target_type}\"%}\n\n{% end_module_block %}"
+      "{% targeted_module_attribute 'my_targeted_module_attribute' \n\tcriterion_id='${1:criterion_id}', \n\torder='${2:order}', \n\ttarget_type='${3:target_type}'%}\n\n{% end_module_block %}"
     ],
     "description": "Defines a smart object parameter for a module. Only valid within a module_block tag definition.\nParameters:\n- criterion_id(number) The smart rule ID number (set up in Template Builder and clone to file)\n- order(String) Zero indexed order of smart rules\n- target_type(String) Type of smart module",
     "prefix": "~targeted_module_attribute"
   },
   "targeted_widget_attribute": {
     "body": [
-      "{% targeted_widget_attribute \"my_targeted_widget_attribute\" \n\tcriterion_id=\"${1:criterion_id}\", \n\torder=\"${2:order}\", \n\ttarget_type=\"${3:target_type}\"%}\n\n{% end_widget_block %}"
+      "{% targeted_widget_attribute 'my_targeted_widget_attribute' \n\tcriterion_id='${1:criterion_id}', \n\torder='${2:order}', \n\ttarget_type='${3:target_type}'%}\n\n{% end_widget_block %}"
     ],
     "description": "Defines a smart object parameter for a widget. Only valid within a widget_block tag definition.\nParameters:\n- criterion_id(number) The smart rule ID number (set up in Template Builder and clone to file)\n- order(String) Zero indexed order of smart rules\n- target_type(String) Type of smart module",
     "prefix": "~targeted_widget_attribute"
   },
   "text": {
     "body": [
-      "{% text \"my_text\" \n\tvalue=\"${1:value}\"%}"
+      "{% text 'my_text' \n\tvalue='${1:value}'%}"
     ],
     "description": "A single line of text with no formatting\nParameters:\n- value(String) Sets the default text of the single line text field",
     "prefix": "~text"
   },
   "textarea": {
     "body": [
-      "{% textarea \"my_textarea\" \n\tvalue=\"${1:value}\"%}"
+      "{% textarea 'my_textarea' \n\tvalue='${1:value}'%}"
     ],
     "description": "Creates an editable plaintext text area\nParameters:\n- value(String) Sets the default text of the textarea",
     "prefix": "~textarea"
   },
   "unless": {
     "body": [
-      "{% unless \"my_unless\" \n\texpr=\"${1:expr}\"%}\n\n{% endunless %}"
+      "{% unless 'my_unless' \n\texpr='${1:expr}'%}\n\n{% endunless %}"
     ],
     "description": "Unless is a conditional just like 'if' but works on the inverse logic.\nParameters:\n- expr(expression) Condition to evaluate",
     "prefix": "~unless"
   },
   "video_player": {
     "body": [
-      "{% video_player \"my_video_player\" \n\tplayer_id=\"${1:player_id}\", \n\ttype=\"${2:type}\", \n\twidth=\"${3:width}\", \n\theight=\"${4:height}\", \n\thide_playlist=\"${5:hide_playlist}\", \n\tviral_sharing=\"${6:viral_sharing}\", \n\tembed_button=\"${7:embed_button}\", \n\tcolor=\"${8:color}\", \n\tplaylist_color=\"${9:playlist_color}\", \n\tplay_button_color=\"${10:play_button_color}\", \n\tstyle=\"${11:style}\", \n\tconversion_asset=\"${12:conversion_asset}\", \n\tplaceholder_alt_text=\"${13:placeholder_alt_text}\", \n\tautoplay=\"${14:autoplay}\", \n\tloop=\"${15:loop}\", \n\tmuted=\"${16:muted}\", \n\thidden_controls=\"${17:hidden_controls}\"%}"
+      "{% video_player 'my_video_player' \n\tplayer_id='${1:player_id}', \n\ttype='${2:type}', \n\twidth='${3:width}', \n\theight='${4:height}', \n\thide_playlist='${5:hide_playlist}', \n\tviral_sharing='${6:viral_sharing}', \n\tembed_button='${7:embed_button}', \n\tcolor='${8:color}', \n\tplaylist_color='${9:playlist_color}', \n\tplay_button_color='${10:play_button_color}', \n\tstyle='${11:style}', \n\tconversion_asset='${12:conversion_asset}', \n\tplaceholder_alt_text='${13:placeholder_alt_text}', \n\tautoplay='${14:autoplay}', \n\tloop='${15:loop}', \n\tmuted='${16:muted}', \n\thidden_controls='${17:hidden_controls}', \n\tfull_width='${18:full_width}'%}"
     ],
-    "description": "A video player\nParameters:\n- player_id(number) Id of the video player\n- type(String) Type of the player embed code. The value can be iframe, script, or scriptv4\n- width(number) Set the width attribute of the video player\n- height(number) Set the height attribute of the video player\n- hide_playlist(boolean) Hide the playlist if set to true\n- viral_sharing(boolean) Display the social networks sharing button on the player if set to true\n- embed_button(boolean) Display embed button on the player if set to true\n- color(String) Player color\n- playlist_color(String) Playlist color\n- play_button_color(String) Player play button color\n- style(String) Additional style for player\n- conversion_asset(String) Event setting for player\n- placeholder_alt_text(String) Alt text for video placeholder image\n- autoplay(boolean) Plays the video on page load if set to true\n- loop(boolean) Loops the video if set to true\n- muted(boolean) Mute the player on load if set to true\n- hidden_controls(boolean) Hide controls on the player if set to true",
+    "description": "A video player\nParameters:\n- player_id(number) Id of the video player\n- type(String) Type of the player embed code. The value can be iframe, script, or scriptv4\n- width(number) Set the width attribute of the video player\n- height(number) Set the height attribute of the video player\n- hide_playlist(boolean) Hide the playlist if set to true\n- viral_sharing(boolean) Display the social networks sharing button on the player if set to true\n- embed_button(boolean) Display embed button on the player if set to true\n- color(String) Player color\n- playlist_color(String) Playlist color\n- play_button_color(String) Player play button color\n- style(String) Additional style for player\n- conversion_asset(String) Event setting for player\n- placeholder_alt_text(String) Alt text for video placeholder image\n- autoplay(boolean) Plays the video on page load if set to true\n- loop(boolean) Loops the video if set to true\n- muted(boolean) Mute the player on load if set to true\n- hidden_controls(boolean) Hide controls on the player if set to true\n- full_width(boolean) Make player fit it's container by width",
     "prefix": "~video_player"
   },
   "widget_attribute": {
     "body": [
-      "{% widget_attribute \"my_widget_attribute\" %}\n\n{% end_widget_block %}"
+      "{% widget_attribute 'my_widget_attribute' %}\n\n{% end_widget_block %}"
     ],
     "description": "Defines a rich attribute for a widget. Only valid within a widget_block tag",
     "prefix": "~widget_attribute"
   },
   "widget_block": {
     "body": [
-      "{% widget_block \"my_widget_block\" \n\twidgetType=\"${1:widgetType}\"%}\n\n{% end_widget_block %}"
+      "{% widget_block 'my_widget_block' \n\twidgetType='${1:widgetType}'%}\n\n{% end_widget_block %}"
     ],
     "description": "A widget block can be used to define widget attribute values with rich content, using widget_attribute tags\nParameters:\n- widgetType(valid HubL module type) ",
     "prefix": "~widget_block"
   },
   "widget_container": {
     "body": [
-      "{% widget_container \"my_widget_container\" %}\n\n{% end_widget_container %}"
+      "{% widget_container 'my_widget_container' %}\n\n{% end_widget_container %}"
     ],
     "description": "Flexible column",
     "prefix": "~widget_container"
   },
   "widget_wrapper": {
     "body": [
-      "{% widget_wrapper \"my_widget_wrapper\" %}\n\n{% end_widget_wrapper %}"
+      "{% widget_wrapper 'my_widget_wrapper' %}\n\n{% end_widget_wrapper %}"
     ],
     "description": "Used to compile an inline widget_wrapper from code",
     "prefix": "~widget_wrapper"


### PR DESCRIPTION
Changes snippet quotes from double to single to match up with the [CMS Boilerplate Styleguide](https://github.com/HubSpot/cms-theme-boilerplate/blob/master/STYLEGUIDE.md)

Fixes #85 