### PR TITLE
Fix typo in group snippet

### DIFF
--- a/snippets/man_gen/hubl_custom_module_fields.json
+++ b/snippets/man_gen/hubl_custom_module_fields.json
@@ -10,7 +10,7 @@
       "\"children\": [${3}],",
       "\"type\": \"group\",",
       "\"inline_help_text\": \"\",",
-      "\"help_text\": \"\"",
+      "\"help_text\": \"\",",
       "\"default\": {} }"
     ],
     "description": "HubSpot Field Group"


### PR DESCRIPTION
Adds in missing comma: 
![image](https://user-images.githubusercontent.com/9009552/98979692-a50cee00-24e9-11eb-988e-db78eb82c704.png)

Fixes #90 