### PR TITLE
Add better DND area snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,10 @@
                 "path": "./snippets/man_gen/hubl_required_email_template_variables.json"
             },
             {
+                "language": "html-hubl",
+                "path": "./snippets/man_gen/default_modules.json"
+            },
+            {
                 "language": "css-hubl",
                 "path": "./snippets/auto_gen/hubl_filters.json"
             },

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -27,8 +27,8 @@ const OMIT_SNIPPET = [
   'dnd_section',
   'dnd_row',
   'dnd_column',
-  'dnd_module'
-]
+  'dnd_module',
+];
 
 const fetchHubldocs = async () => {
   const HUBLDOC_ENDPOINT = 'https://api.hubspot.com/cos-rendering/v1/hubldoc';
@@ -92,8 +92,9 @@ const buildSnippetDescription = (docEntry) => {
     description += '\nParameters:';
 
     for (let param of params) {
-      description += `\n- ${param.name.replace(' ', '_')}(${param.type}) ${param.desc
-        }`;
+      description += `\n- ${param.name.replace(' ', '_')}(${param.type}) ${
+        param.desc
+      }`;
     }
   }
 

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -22,6 +22,14 @@ const SKIP_SNIPPET_GENERATION = [
   'module_attribute',
 ];
 
+const OMIT_SNIPPET = [
+  'dnd_area',
+  'dnd_section',
+  'dnd_row',
+  'dnd_column',
+  'dnd_module'
+]
+
 const fetchHubldocs = async () => {
   const HUBLDOC_ENDPOINT = 'https://api.hubspot.com/cos-rendering/v1/hubldoc';
   const response = await fetch(HUBLDOC_ENDPOINT);
@@ -77,16 +85,15 @@ const buildSnippetBody = (
 };
 
 const buildSnippetDescription = (docEntry) => {
-  const { desc, params } = docEntry;
+  const { desc, params = [] } = docEntry;
   let description = desc;
 
   if (params.length > 0) {
     description += '\nParameters:';
 
     for (let param of params) {
-      description += `\n- ${param.name.replace(' ', '_')}(${param.type}) ${
-        param.desc
-      }`;
+      description += `\n- ${param.name.replace(' ', '_')}(${param.type}) ${param.desc
+        }`;
     }
   }
 
@@ -98,6 +105,10 @@ const getFirstDefaultSnippet = (docEntry) => {
 };
 
 const createSnippet = (docEntry, type) => {
+  if (OMIT_SNIPPET.includes(docEntry.name)) {
+    return;
+  }
+
   let snippetEntry = {
     body: [
       SKIP_SNIPPET_GENERATION.includes(docEntry.name)

--- a/snippets/auto_gen/hubl_tags.json
+++ b/snippets/auto_gen/hubl_tags.json
@@ -83,41 +83,6 @@
     "description": "The cycle tag can be used within a for loop to cycle through a series of string values and print them with each iteration\nParameters:\n- string_to_print(String) A comma separated list of strings to print with each interation. The list will repeat if there are more iterations than string parameter values.",
     "prefix": "~cycle"
   },
-  "dnd_area": {
-    "body": [
-      "{% dnd_area 'my_dnd_area' \n\tname='${1:name}', \n\tlabel='${2:label}', \n\tclass='${3:class}'%}\n\n{% end_dnd_area %}"
-    ],
-    "description": "Creates container that supports drag-and-drop in content editors.\nParameters:\n- name(string) Identifier when storing data for a drag-and-drop area in the editors. Must be unique for all drag-and-drop areas in a template.\n- label(string) Label used in the editor for the drag-and-drop area.\n- class(string) Class names to add to the wrapping div.",
-    "prefix": "~dnd_area"
-  },
-  "dnd_column": {
-    "body": [
-      "{% dnd_column 'my_dnd_column' \n\toffset='${1:offset}', \n\twidth='${2:width}', \n\tmargin='${3:margin}', \n\tbackground_image='${4:background_image}', \n\tbackground_color='${5:background_color}'%}\n\n{% end_dnd_column %}"
-    ],
-    "description": "A column inside a drag-and-drop area. Columns can only be children of a section or a row tag.\nParameters:\n- offset(integer) Number of rows to offset the module in the row (0-11).\n- width(integer) Number of rows wide the module should be.\n- margin(dict) Add top and bottom margin in pixels.\n- background_image(dict) Add a background image to the row.\n- background_color(dict) Specify a background color for the the row.",
-    "prefix": "~dnd_column"
-  },
-  "dnd_module": {
-    "body": [
-      "{% dnd_module 'my_dnd_module' \n\tpath='${1:path}', \n\toffset='${2:offset}', \n\twidth='${3:width}', \n\tflexbox_positioning='${4:flexbox_positioning}'%}\n\n{% end_dnd_module %}"
-    ],
-    "description": "Creates a wrapped module inside a drag-and-drop area.\nParameters:\n- path(string) Path to the module.\n- offset(integer) Number of rows to offset the module in the row (0-11).\n- width(integer) Number of rows wide the module should be.\n- flexbox_positioning(string) Adjust position of the module inside the row. Possible values are TOP_LEFT, TOP_CENTER, or TOP_RIGHT.",
-    "prefix": "~dnd_module"
-  },
-  "dnd_row": {
-    "body": [
-      "{% dnd_row 'my_dnd_row' \n\tmargin='${1:margin}', \n\tpadding='${2:padding}', \n\tbackground_image='${3:background_image}', \n\tbackground_color='${4:background_color}'%}\n\n{% end_dnd_row %}"
-    ],
-    "description": "A row inside a drag-and-drop area. Rows can only be children of columns.\nParameters:\n- margin(dict) Add top and bottom margin in pixels.\n- padding(dict) Add top, bottom, left, and right padding in pixels.\n- background_image(dict) Add a background image to the row.\n- background_color(dict) Specify a background color for the the row.",
-    "prefix": "~dnd_row"
-  },
-  "dnd_section": {
-    "body": [
-      "{% dnd_section 'my_dnd_section' \n\tmax_width='${1:max_width}', \n\tmargin='${2:margin}', \n\tpadding='${3:padding}', \n\tbackground_image='${4:background_image}', \n\tbackground_color='${5:background_color}'%}\n\n{% end_dnd_section %}"
-    ],
-    "description": "A top-level row inside a drag-and-drop area. Sections can only be children of a drag-and-drop area tag.\nParameters:\n- max_width(number) Maximum width of the section.\n- margin(dict) Add top and bottom margin in pixels.\n- padding(dict) Add top, bottom, left, and right padding in pixels.\n- background_image(dict) Add a background image to the row.\n- background_color(dict) Specify a background color for the the row.",
-    "prefix": "~dnd_section"
-  },
   "do": {
     "body": [
       "{% do list.append('value 2') %}"

--- a/snippets/auto_gen/hubl_tags.json
+++ b/snippets/auto_gen/hubl_tags.json
@@ -328,6 +328,13 @@
     "description": "A module\nParameters:\n- module_id(String) The id of the module to render\n- path(String) The path of the module to render. Include leading slash for absolute path, otherwise path is relative to template. Reference HubSpot default modules with paths corresponding to their HubL tags such as @hubspot/rich_text, @hubspot/linked_image, etc.",
     "prefix": "~module"
   },
+  "module_attribute": {
+    "body": [
+      "{% module_block rich_text \"my_text_block\" overrideable=True, label=\"Right Column\" %}\n   {% module_attribute \"html\" %}\n       <h2>Something Powerful</h2>\n       <p>Some paragraph content...</p>\n   {% end_module_attribute %}\n{% end_module_block %}"
+    ],
+    "description": "Defines a rich attribute for a module. Only valid within a module_block tag",
+    "prefix": "~module_attribute"
+  },
   "page_footer": {
     "body": [
       "{% page_footer 'my_page_footer' %}"

--- a/snippets/man_gen/default_modules.json
+++ b/snippets/man_gen/default_modules.json
@@ -15,7 +15,7 @@
       "\t${6:horizontal_alignment='${7|left,center,right|}}'",
       "%}",
       "$8",
-      "{% end_dnd_module %}$9"
+      "{% end_dnd_module %}"
     ],
     "description": "Creates a wrapped module inside a drag-and-drop area.\nParameters:\n- path(string) Path to the module.\n- offset(integer) Number of rows to offset the module in the row (0-11).\n- width(integer) Number of rows wide the module should be.\n- flexbox_positioning(string) Adjust position of the module inside the row. Possible values are TOP_LEFT, TOP_CENTER, or TOP_RIGHT.",
     "prefix": "default_dnd_module"
@@ -28,8 +28,7 @@
       "\t${4:offset=${5:0},}",
       "\t${6:horizontal_alignment='${7|left,center,right|}}'",
       "%}",
-      "$8",
-      "{% end_dnd_module %}$9"
+      "{% end_dnd_module %}"
     ],
     "description": "Creates a wrapped module inside a drag-and-drop area.\nParameters:\n- path(string) Path to the module.\n- offset(integer) Number of rows to offset the module in the row (0-11).\n- width(integer) Number of rows wide the module should be.\n- flexbox_positioning(string) Adjust position of the module inside the row. Possible values are TOP_LEFT, TOP_CENTER, or TOP_RIGHT.",
     "prefix": "dnd_module"
@@ -47,55 +46,67 @@
     "body": [
       "{% dnd_column",
       "\twidth=${1:6}",
-      "\t${3:offset=${2:0},}",
-      "${5:\tmargin={",
-      "\t\t'top': ${6:32},",
-      "\t\t'bottom': ${7:32}",
+      "\t${2:offset=${3:0},}",
+      "${4:\tmargin={",
+      "\t\t'top': ${5:32},",
+      "\t\t'bottom': ${6:32}",
       "\t\\},}",
-      "${8:\tpadding={",
-      "\t\t'top': ${9:10},",
-      "\t\t'bottom': ${10:10},",
-      "\t\t'left': ${11:10},",
-      "\t\t'right': ${12:10}",
+      "${7:\tpadding={",
+      "\t\t'top': ${8:10},",
+      "\t\t'bottom': ${9:10},",
+      "\t\t'left': ${10:10},",
+      "\t\t'right': ${11:10}",
       "\t\\},}",
-      "${13:\tmax_width=${14:1200},}",
-      "${15:\tvertical_alignment='${16|TOP,MIDDLE,BOTTOM|}'}",
+      "${12:\tmax_width=${13:1200},}",
+      "${14:\tvertical_alignment='${15|TOP,MIDDLE,BOTTOM|}'}",
       "%}",
-      "\t$17",
-      "{% end_dnd_column %}$18"
+      "\t$0",
+      "{% end_dnd_column %}"
     ],
     "description": "A column inside a drag-and-drop area. Columns can only be children of a section or a row tag.\nParameters:\n- offset(integer) Number of rows to offset the module in the row (0-11).\n- width(integer) Number of rows wide the module should be.\n- margin(dict) Add top and bottom margin in pixels.\n- background_image(dict) Add a background image to the row.\n- background_color(dict) Specify a background color for the the row.",
     "prefix": "column"
   },
-  "dnd_row": {
-    "body": [
-      "{% dnd_row %}",
-      "\t$0",
-      "{% end_dnd_row %}$1"
-    ],
-    "description": "A row inside a drag-and-drop area. Rows can only be children of columns.\nParameters:\n- margin(dict) Add top and bottom margin in pixels.\n- padding(dict) Add top, bottom, left, and right padding in pixels.\n- background_image(dict) Add a background image to the row.\n- background_color(dict) Specify a background color for the the row.",
-    "prefix": "row"
-  },
   "dnd_section": {
     "body": [
       "{% dnd_section ",
-      "${5:\tmargin={",
-      "\t\t'top': ${6:32},",
-      "\t\t'bottom': ${7:32}",
+      "${1:\tmargin={",
+      "\t\t'top': ${2:32},",
+      "\t\t'bottom': ${3:32}",
       "\t\\},}",
-      "${8:\tpadding={",
-      "\t\t'top': ${9:10},",
-      "\t\t'bottom': ${10:10},",
-      "\t\t'left': ${11:10},",
-      "\t\t'right': ${12:10}",
+      "${4:\tpadding={",
+      "\t\t'top': ${5:10},",
+      "\t\t'bottom': ${6:10},",
+      "\t\t'left': ${7:10},",
+      "\t\t'right': ${8:10}",
       "\t\\},}",
-      "${13:\tmax_width=${14:1200},}",
-      "${15:\tvertical_alignment='${16|TOP,MIDDLE,BOTTOM|}'}",
+      "${9:\tmax_width=${10:1200},}",
+      "${11:\tvertical_alignment='${12|TOP,MIDDLE,BOTTOM|}'}",
       "%}",
       "\t$0",
       "{% end_dnd_section %}"
     ],
     "description": "A top-level row inside a drag-and-drop area. Sections can only be children of a drag-and-drop area tag.\nParameters:\n- max_width(number) Maximum width of the section.\n- margin(dict) Add top and bottom margin in pixels.\n- padding(dict) Add top, bottom, left, and right padding in pixels.\n- background_image(dict) Add a background image to the row.\n- background_color(dict) Specify a background color for the the row.",
     "prefix": "section"
+  },
+  "dnd_row": {
+    "body": [
+      "{% dnd_row ",
+      "${1:\tmargin={",
+      "\t\t'top': ${2:32},",
+      "\t\t'bottom': ${3:32}",
+      "\t\\},}",
+      "${4:\tpadding={",
+      "\t\t'top': ${5:10},",
+      "\t\t'bottom': ${6:10},",
+      "\t\t'left': ${7:10},",
+      "\t\t'right': ${8:10}",
+      "\t\\},}",
+      "${9:\tvertical_alignment='${10|TOP,MIDDLE,BOTTOM|}'}",
+      "%}",
+      "\t$0",
+      "{% end_dnd_row %}"
+    ],
+    "description": "A row inside a drag-and-drop area. Rows can only be children of columns.\nParameters:\n- margin(dict) Add top and bottom margin in pixels.\n- padding(dict) Add top, bottom, left, and right padding in pixels.\n- background_image(dict) Add a background image to the row.\n- background_color(dict) Specify a background color for the the row.",
+    "prefix": "row"
   }
 }

--- a/snippets/man_gen/default_modules.json
+++ b/snippets/man_gen/default_modules.json
@@ -69,9 +69,9 @@
   },
   "dnd_row": {
     "body": [
-      "{% dnd_area '${1:name}' ${2:\tclass='${3:class}'} %}",
+      "{% dnd_row %}",
       "\t$0",
-      "{% end_dnd_area %}"
+      "{% end_dnd_row %}$1"
     ],
     "description": "A row inside a drag-and-drop area. Rows can only be children of columns.\nParameters:\n- margin(dict) Add top and bottom margin in pixels.\n- padding(dict) Add top, bottom, left, and right padding in pixels.\n- background_image(dict) Add a background image to the row.\n- background_color(dict) Specify a background color for the the row.",
     "prefix": "row"

--- a/snippets/man_gen/default_modules.json
+++ b/snippets/man_gen/default_modules.json
@@ -1,0 +1,101 @@
+{
+  "Default HubSpot module": {
+    "body": [
+      "{% module '${1:name}' \n\tpath='${2|@hubspot/blog_comments,@hubspot/blog_subscribe,@hubspot/button,@hubspot/button_email,@hubspot/cta,@hubspot/divider,@hubspot/email_body,@hubspot/email_can_spam,@hubspot/email_divider,@hubspot/email_footer,@hubspot/email_simple_subscription,@hubspot/email_subscriptions,@hubspot/email_subscriptions_confirmation,@hubspot/email_survey,@hubspot/email_view_as_web_page,@hubspot/email_web_version_link,@hubspot/follow_me,@hubspot/follow_me_email,@hubspot/follow_me_lp,@hubspot/form,@hubspot/gallery,@hubspot/header,@hubspot/horizontal_spacer,@hubspot/image_email,@hubspot/language_switcher,@hubspot/linked_image,@hubspot/logo,@hubspot/meetings,@hubspot/menu,@hubspot/page_footer,@hubspot/password_prompt,@hubspot/post_filter,@hubspot/post_listing,@hubspot/raw_html_email,@hubspot/rich_text,@hubspot/rss_listing,@hubspot/search_input,@hubspot/search_results,@hubspot/section_header,@hubspot/simple_menu,@hubspot/social_sharing,@hubspot/text,@hubspot/video,@hubspot/video_email,@hubspot/video_embed_lp|}'%}"
+    ],
+    "description": "A module\nParameters:\n- module_id(String) The id of the module to render\n- path(String) The path of the module to render. Include leading slash for absolute path, otherwise path is relative to template. Reference HubSpot default modules with paths corresponding to their HubL tags such as @hubspot/rich_text, @hubspot/linked_image, etc.",
+    "prefix": "default_module"
+  },
+  "default dnd module": {
+    "body": [
+      "{% dnd_module '${1:name}'",
+      "\tpath='${2|@hubspot/blog_comments,@hubspot/blog_subscribe,@hubspot/button,@hubspot/button_email,@hubspot/cta,@hubspot/divider,@hubspot/email_body,@hubspot/email_can_spam,@hubspot/email_divider,@hubspot/email_footer,@hubspot/email_simple_subscription,@hubspot/email_subscriptions,@hubspot/email_subscriptions_confirmation,@hubspot/email_survey,@hubspot/email_view_as_web_page,@hubspot/email_web_version_link,@hubspot/follow_me,@hubspot/follow_me_email,@hubspot/follow_me_lp,@hubspot/form,@hubspot/gallery,@hubspot/header,@hubspot/horizontal_spacer,@hubspot/image_email,@hubspot/language_switcher,@hubspot/linked_image,@hubspot/logo,@hubspot/meetings,@hubspot/menu,@hubspot/page_footer,@hubspot/password_prompt,@hubspot/post_filter,@hubspot/post_listing,@hubspot/raw_html_email,@hubspot/rich_text,@hubspot/rss_listing,@hubspot/search_input,@hubspot/search_results,@hubspot/section_header,@hubspot/simple_menu,@hubspot/social_sharing,@hubspot/text,@hubspot/video,@hubspot/video_email,@hubspot/video_embed_lp|}',",
+      "\twidth=${3:6}",
+      "\t${4:offset=${5:0},}",
+      "\t${6:horizontal_alignment='${7|left,center,right|}}'",
+      "%}",
+      "$8",
+      "{% end_dnd_module %}$9"
+    ],
+    "description": "Creates a wrapped module inside a drag-and-drop area.\nParameters:\n- path(string) Path to the module.\n- offset(integer) Number of rows to offset the module in the row (0-11).\n- width(integer) Number of rows wide the module should be.\n- flexbox_positioning(string) Adjust position of the module inside the row. Possible values are TOP_LEFT, TOP_CENTER, or TOP_RIGHT.",
+    "prefix": "default_dnd_module"
+  },
+  "dnd module": {
+    "body": [
+      "{% dnd_module '${1:name}'",
+      "\tpath='${2:path}'",
+      "\twidth=${3:6}",
+      "\t${4:offset=${5:0},}",
+      "\t${6:horizontal_alignment='${7|left,center,right|}}'",
+      "%}",
+      "$8",
+      "{% end_dnd_module %}$9"
+    ],
+    "description": "Creates a wrapped module inside a drag-and-drop area.\nParameters:\n- path(string) Path to the module.\n- offset(integer) Number of rows to offset the module in the row (0-11).\n- width(integer) Number of rows wide the module should be.\n- flexbox_positioning(string) Adjust position of the module inside the row. Possible values are TOP_LEFT, TOP_CENTER, or TOP_RIGHT.",
+    "prefix": "dnd_module"
+  },
+  "dnd_area": {
+    "body": [
+      "{% dnd_area '${1:name}' ${2:\tclass='${3:class}'} %}",
+      "\t$0",
+      "{% end_dnd_area %}"
+    ],
+    "description": "Creates container that supports drag-and-drop in content editors.\nParameters:\n- name(string) Identifier when storing data for a drag-and-drop area in the editors. Must be unique for all drag-and-drop areas in a template.\n- label(string) Label used in the editor for the drag-and-drop area.\n- class(string) Class names to add to the wrapping div.",
+    "prefix": "area"
+  },
+  "dnd_column": {
+    "body": [
+      "{% dnd_column",
+      "\twidth=${1:6}",
+      "\t${3:offset=${2:0},}",
+      "${5:\tmargin={",
+      "\t\t'top': ${6:32},",
+      "\t\t'bottom': ${7:32}",
+      "\t\\},}",
+      "${8:\tpadding={",
+      "\t\t'top': ${9:10},",
+      "\t\t'bottom': ${10:10},",
+      "\t\t'left': ${11:10},",
+      "\t\t'right': ${12:10}",
+      "\t\\},}",
+      "${13:\tmax_width=${14:1200},}",
+      "${15:\tvertical_alignment='${16|TOP,MIDDLE,BOTTOM|}'}",
+      "%}",
+      "\t$17",
+      "{% end_dnd_column %}$18"
+    ],
+    "description": "A column inside a drag-and-drop area. Columns can only be children of a section or a row tag.\nParameters:\n- offset(integer) Number of rows to offset the module in the row (0-11).\n- width(integer) Number of rows wide the module should be.\n- margin(dict) Add top and bottom margin in pixels.\n- background_image(dict) Add a background image to the row.\n- background_color(dict) Specify a background color for the the row.",
+    "prefix": "column"
+  },
+  "dnd_row": {
+    "body": [
+      "{% dnd_area '${1:name}' ${2:\tclass='${3:class}'} %}",
+      "\t$0",
+      "{% end_dnd_area %}"
+    ],
+    "description": "A row inside a drag-and-drop area. Rows can only be children of columns.\nParameters:\n- margin(dict) Add top and bottom margin in pixels.\n- padding(dict) Add top, bottom, left, and right padding in pixels.\n- background_image(dict) Add a background image to the row.\n- background_color(dict) Specify a background color for the the row.",
+    "prefix": "row"
+  },
+  "dnd_section": {
+    "body": [
+      "{% dnd_section ",
+      "${5:\tmargin={",
+      "\t\t'top': ${6:32},",
+      "\t\t'bottom': ${7:32}",
+      "\t\\},}",
+      "${8:\tpadding={",
+      "\t\t'top': ${9:10},",
+      "\t\t'bottom': ${10:10},",
+      "\t\t'left': ${11:10},",
+      "\t\t'right': ${12:10}",
+      "\t\\},}",
+      "${13:\tmax_width=${14:1200},}",
+      "${15:\tvertical_alignment='${16|TOP,MIDDLE,BOTTOM|}'}",
+      "%}",
+      "\t$0",
+      "{% end_dnd_section %}"
+    ],
+    "description": "A top-level row inside a drag-and-drop area. Sections can only be children of a drag-and-drop area tag.\nParameters:\n- max_width(number) Maximum width of the section.\n- margin(dict) Add top and bottom margin in pixels.\n- padding(dict) Add top, bottom, left, and right padding in pixels.\n- background_image(dict) Add a background image to the row.\n- background_color(dict) Specify a background color for the the row.",
+    "prefix": "section"
+  }
+}


### PR DESCRIPTION
Adds more robust, nestable dnd area tag snippets to make authoring DND areas quicker.

A WIP example:
![snippets](https://user-images.githubusercontent.com/9009552/115924506-d05b1800-a44d-11eb-9cc8-e533d65dea12.gif)
