### PR TITLE
Show notification to user if Beta hasn't been enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const {
 } = require('@hubspot/cli-lib');
 const { enableLinting, disableLinting } = require('./lib/lint');
 const { trackUsage } = require('@hubspot/cli-lib/api/fileMapper');
+const { notifyBeta } = require('./lib/notify');
 
 async function activate(context) {
   const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -63,6 +64,8 @@ async function activate(context) {
 
   if (vscode.workspace.getConfiguration('hubspot').get('beta')) {
     enableLinting();
+  } else {
+    notifyBeta(context);
   }
 
   context.subscriptions.push(

--- a/index.js
+++ b/index.js
@@ -10,7 +10,10 @@ const {
 const { enableLinting, disableLinting } = require('./lib/lint');
 const { trackUsage } = require('@hubspot/cli-lib/api/fileMapper');
 const { notifyBeta } = require('./lib/notify');
-const {EXTENSION_CONFIG_NAME, EXTENSION_CONFIG_KEYS} = require('./lib/constants');
+const {
+  EXTENSION_CONFIG_NAME,
+  EXTENSION_CONFIG_KEYS,
+} = require('./lib/constants');
 
 async function activate(context) {
   const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -63,7 +66,11 @@ async function activate(context) {
 
   await trackAction('extension-activated');
 
-  if (vscode.workspace.getConfiguration(EXTENSION_CONFIG_NAME).get(EXTENSION_CONFIG_KEYS.BETA)) {
+  if (
+    vscode.workspace
+      .getConfiguration(EXTENSION_CONFIG_NAME)
+      .get(EXTENSION_CONFIG_KEYS.BETA)
+  ) {
     enableLinting();
   } else {
     notifyBeta(context);
@@ -71,8 +78,16 @@ async function activate(context) {
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration(async (e) => {
-      if (e.affectsConfiguration(`${EXTENSION_CONFIG_NAME}.${EXTENSION_CONFIG_KEYS.BETA}`)) {
-        if (vscode.workspace.getConfiguration(EXTENSION_CONFIG_NAME).get(EXTENSION_CONFIG_KEYS.BETA)) {
+      if (
+        e.affectsConfiguration(
+          `${EXTENSION_CONFIG_NAME}.${EXTENSION_CONFIG_KEYS.BETA}`
+        )
+      ) {
+        if (
+          vscode.workspace
+            .getConfiguration(EXTENSION_CONFIG_NAME)
+            .get(EXTENSION_CONFIG_KEYS.BETA)
+        ) {
           enableLinting();
           await trackAction('beta-enabled');
         } else {

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const {
 const { enableLinting, disableLinting } = require('./lib/lint');
 const { trackUsage } = require('@hubspot/cli-lib/api/fileMapper');
 const { notifyBeta } = require('./lib/notify');
+const {EXTENSION_CONFIG_NAME, EXTENSION_CONFIG_KEYS} = require('./lib/constants');
 
 async function activate(context) {
   const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -62,7 +63,7 @@ async function activate(context) {
 
   await trackAction('extension-activated');
 
-  if (vscode.workspace.getConfiguration('hubspot').get('beta')) {
+  if (vscode.workspace.getConfiguration(EXTENSION_CONFIG_NAME).get(EXTENSION_CONFIG_KEYS.BETA)) {
     enableLinting();
   } else {
     notifyBeta(context);
@@ -70,8 +71,8 @@ async function activate(context) {
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration(async (e) => {
-      if (e.affectsConfiguration('hubspot.beta')) {
-        if (vscode.workspace.getConfiguration('hubspot').get('beta')) {
+      if (e.affectsConfiguration(`${EXTENSION_CONFIG_NAME}.${EXTENSION_CONFIG_KEYS.BETA}`)) {
+        if (vscode.workspace.getConfiguration(EXTENSION_CONFIG_NAME).get(EXTENSION_CONFIG_KEYS.BETA)) {
           enableLinting();
           await trackAction('beta-enabled');
         } else {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -24,6 +24,10 @@ const EXTENSION_CONFIG_KEYS = {
   BETA: 'beta',
 };
 
+const GLOBAL_STATE_KEYS = {
+  HAS_SEEN_LINTING_MESSAGE: 'HS_HAS_SEEN_LINTING_MESSAGE',
+};
+
 // Used when VS Code attempts to find the correct range of characters to select
 const HUBL_TAG_DEFINITION_REGEX = /{%.*(.*).*%}/;
 
@@ -32,5 +36,6 @@ module.exports = {
   VSCODE_SEVERITY,
   EXTENSION_CONFIG_NAME,
   EXTENSION_CONFIG_KEYS,
+  GLOBAL_STATE_KEYS,
   HUBL_TAG_DEFINITION_REGEX,
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -18,11 +18,19 @@ const VSCODE_SEVERITY = {
   OTHER: 'Information',
 };
 
+const EXTENSION_CONFIG_NAME = "hubspot";
+
+const EXTENSION_CONFIG_KEYS = {
+  "BETA": "beta"
+}
+
 // Used when VS Code attempts to find the correct range of characters to select
 const HUBL_TAG_DEFINITION_REGEX = /{%.*(.*).*%}/;
 
 module.exports = {
   TEMPLATE_ERRORS_TYPES,
   VSCODE_SEVERITY,
-  HUBL_TAG_DEFINITION_REGEX,
+  EXTENSION_CONFIG_NAME,
+  EXTENSION_CONFIG_KEYS,
+  HUBL_TAG_DEFINITION_REGEX
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -18,11 +18,11 @@ const VSCODE_SEVERITY = {
   OTHER: 'Information',
 };
 
-const EXTENSION_CONFIG_NAME = "hubspot";
+const EXTENSION_CONFIG_NAME = 'hubspot';
 
 const EXTENSION_CONFIG_KEYS = {
-  "BETA": "beta"
-}
+  BETA: 'beta',
+};
 
 // Used when VS Code attempts to find the correct range of characters to select
 const HUBL_TAG_DEFINITION_REGEX = /{%.*(.*).*%}/;
@@ -32,5 +32,5 @@ module.exports = {
   VSCODE_SEVERITY,
   EXTENSION_CONFIG_NAME,
   EXTENSION_CONFIG_KEYS,
-  HUBL_TAG_DEFINITION_REGEX
+  HUBL_TAG_DEFINITION_REGEX,
 };

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,6 +1,6 @@
 const { window } = require('vscode');
 
-const HAS_SEEN_BETA = 'has-seen-beta';
+const HAS_SEEN_BETA = 'HS_HAS_SEEN_BETA';
 const BETA_NOTIFICATION_MESSAGE =
   'Now in Beta: HubL Error Linting. Opt-in to beta feautures to enable this feature.';
 
@@ -9,6 +9,7 @@ const notifyBeta = (ctx) => {
     return;
   }
   window.showInformationMessage(BETA_NOTIFICATION_MESSAGE);
+  ctx.globalState.update(HAS_SEEN_BETA, true);
 };
 
 module.exports = { notifyBeta };

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,13 +1,18 @@
 const { window, workspace, ConfigurationTarget } = require('vscode');
-const { EXTENSION_CONFIG_NAME, EXTENSION_CONFIG_KEYS } = require('./constants');
+const {
+  EXTENSION_CONFIG_NAME,
+  EXTENSION_CONFIG_KEYS,
+  GLOBAL_STATE_KEYS,
+} = require('./constants');
 
-const HAS_SEEN_BETA = 'HS_HAS_SEEN_BETA';
 const BETA_NOTIFICATION_MESSAGE =
   'Now in Beta: HubL Error Linting. Opt-in to beta feautures to enable this feature.';
 const BETA_NOTIFICATION_BUTTON = 'Enable Beta Features';
 
 const notifyBeta = (ctx) => {
-  if (ctx.globalState.get(HAS_SEEN_BETA) === true) {
+  if (
+    ctx.globalState.get(GLOBAL_STATE_KEYS.HAS_SEEN_LINTING_MESSAGE) === true
+  ) {
     return;
   }
   window
@@ -19,7 +24,7 @@ const notifyBeta = (ctx) => {
           .update(EXTENSION_CONFIG_KEYS.BETA, true, ConfigurationTarget.Global);
       }
     });
-  ctx.globalState.update(HAS_SEEN_BETA, true);
+  ctx.globalState.update(GLOBAL_STATE_KEYS.HAS_SEEN_LINTING_MESSAGE, true);
 };
 
 module.exports = { notifyBeta };

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,4 +1,5 @@
 const { window, workspace, ConfigurationTarget } = require('vscode');
+const {EXTENSION_CONFIG_NAME, EXTENSION_CONFIG_KEYS} = require('./constants');
 
 const HAS_SEEN_BETA = 'HS_HAS_SEEN_BETA';
 const BETA_NOTIFICATION_MESSAGE =
@@ -12,7 +13,7 @@ const notifyBeta = (ctx) => {
   window.showInformationMessage(BETA_NOTIFICATION_MESSAGE, ENABLE_BETA_MESSAGE)
     .then(selection => {
       if (selection === ENABLE_BETA_MESSAGE) {
-        workspace.getConfiguration('hubspot').update('beta', true, ConfigurationTarget.Global)
+        workspace.getConfiguration(EXTENSION_CONFIG_NAME).update(EXTENSION_CONFIG_KEYS.BETA, true, ConfigurationTarget.Global)
       }
     });
   ctx.globalState.update(HAS_SEEN_BETA, true);

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -4,15 +4,15 @@ const {EXTENSION_CONFIG_NAME, EXTENSION_CONFIG_KEYS} = require('./constants');
 const HAS_SEEN_BETA = 'HS_HAS_SEEN_BETA';
 const BETA_NOTIFICATION_MESSAGE =
   'Now in Beta: HubL Error Linting. Opt-in to beta feautures to enable this feature.';
-const ENABLE_BETA_MESSAGE = 'Enable Beta Features';
+const BETA_NOTIFICATION_BUTTON = 'Enable Beta Features';
 
 const notifyBeta = (ctx) => {
   if (ctx.globalState.get(HAS_SEEN_BETA) === true) {
     return;
   }
-  window.showInformationMessage(BETA_NOTIFICATION_MESSAGE, ENABLE_BETA_MESSAGE)
+  window.showInformationMessage(BETA_NOTIFICATION_MESSAGE, BETA_NOTIFICATION_BUTTON)
     .then(selection => {
-      if (selection === ENABLE_BETA_MESSAGE) {
+      if (selection === BETA_NOTIFICATION_BUTTON) {
         workspace.getConfiguration(EXTENSION_CONFIG_NAME).update(EXTENSION_CONFIG_KEYS.BETA, true, ConfigurationTarget.Global)
       }
     });

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,0 +1,14 @@
+const { window } = require('vscode');
+
+const HAS_SEEN_BETA = 'has-seen-beta';
+const BETA_NOTIFICATION_MESSAGE =
+  'Now in Beta: HubL Error Linting. Opt-in to beta feautures to enable this feature.';
+
+const notifyBeta = (ctx) => {
+  if (ctx.globalState.get(HAS_SEEN_BETA) === true) {
+    return;
+  }
+  window.showInformationMessage(BETA_NOTIFICATION_MESSAGE);
+};
+
+module.exports = { notifyBeta };

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,5 +1,5 @@
 const { window, workspace, ConfigurationTarget } = require('vscode');
-const {EXTENSION_CONFIG_NAME, EXTENSION_CONFIG_KEYS} = require('./constants');
+const { EXTENSION_CONFIG_NAME, EXTENSION_CONFIG_KEYS } = require('./constants');
 
 const HAS_SEEN_BETA = 'HS_HAS_SEEN_BETA';
 const BETA_NOTIFICATION_MESSAGE =
@@ -10,10 +10,13 @@ const notifyBeta = (ctx) => {
   if (ctx.globalState.get(HAS_SEEN_BETA) === true) {
     return;
   }
-  window.showInformationMessage(BETA_NOTIFICATION_MESSAGE, BETA_NOTIFICATION_BUTTON)
-    .then(selection => {
+  window
+    .showInformationMessage(BETA_NOTIFICATION_MESSAGE, BETA_NOTIFICATION_BUTTON)
+    .then((selection) => {
       if (selection === BETA_NOTIFICATION_BUTTON) {
-        workspace.getConfiguration(EXTENSION_CONFIG_NAME).update(EXTENSION_CONFIG_KEYS.BETA, true, ConfigurationTarget.Global)
+        workspace
+          .getConfiguration(EXTENSION_CONFIG_NAME)
+          .update(EXTENSION_CONFIG_KEYS.BETA, true, ConfigurationTarget.Global);
       }
     });
   ctx.globalState.update(HAS_SEEN_BETA, true);

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,14 +1,20 @@
-const { window } = require('vscode');
+const { window, workspace, ConfigurationTarget } = require('vscode');
 
 const HAS_SEEN_BETA = 'HS_HAS_SEEN_BETA';
 const BETA_NOTIFICATION_MESSAGE =
   'Now in Beta: HubL Error Linting. Opt-in to beta feautures to enable this feature.';
+const ENABLE_BETA_MESSAGE = 'Enable Beta Features';
 
 const notifyBeta = (ctx) => {
   if (ctx.globalState.get(HAS_SEEN_BETA) === true) {
     return;
   }
-  window.showInformationMessage(BETA_NOTIFICATION_MESSAGE);
+  window.showInformationMessage(BETA_NOTIFICATION_MESSAGE, ENABLE_BETA_MESSAGE)
+    .then(selection => {
+      if (selection === ENABLE_BETA_MESSAGE) {
+        workspace.getConfiguration('hubspot').update('beta', true, ConfigurationTarget.Global)
+      }
+    });
   ctx.globalState.update(HAS_SEEN_BETA, true);
 };
 


### PR DESCRIPTION
To spread awareness of Beta Features, this adds a notification that shows up for users to alert them of the new feature. Adds a button so that they can opt in without visiting settings.

![image](https://user-images.githubusercontent.com/9009552/121713393-ceefb880-caaa-11eb-8242-8f315ec08d56.png)


Note: VSCode doesn't seem to allow any styling (or even new lines) in messages.