### PR TITLE
Fix `cmd+/` comment shortcut

### DIFF
--- a/langconfig/hubl-html-language-configuration.json
+++ b/langconfig/hubl-html-language-configuration.json
@@ -14,6 +14,9 @@
     ["%", "%"],
     ["#", "#"]
   ],
+  "comments": {
+    "blockComment": ["{#", "#}"]
+  },
   "indentationRules": {
     "decreaseIndentPattern": ".*{%(.*?end).*%}*.",
     "increaseIndentPattern": ".*{%(?!.*end).*%}.*"


### PR DESCRIPTION
Fixes #110 