### PR TITLE
Add style field snippets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "hubl",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "hubl",
-            "version": "0.10.0",
+            "version": "0.11.0",
             "dependencies": {
                 "@hubspot/cli-lib": "3.0.4",
                 "fs-extra": "^9.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
             },
             "devDependencies": {
                 "@types/node": "^15.12.4",
-                "@types/vscode": "^1.55.0",
+                "@types/vscode": "1.30.0",
                 "eslint": "^7.5.0",
                 "node-loader": "^2.0.0",
                 "prettier": "^2.0.5",
@@ -231,9 +231,10 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.55.0",
-            "dev": true,
-            "license": "MIT"
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.30.0.tgz",
+            "integrity": "sha512-xRas+PW/fM/MoonB+Pawg48bGTjCqJsFUFwZpH/q2oW80AMHGDAUTUqySBnqeQ18e/SNi7NOCf3ZkYOzKm3Pqw==",
+            "dev": true
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.11.0",
@@ -4456,7 +4457,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.55.0",
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.30.0.tgz",
+            "integrity": "sha512-xRas+PW/fM/MoonB+Pawg48bGTjCqJsFUFwZpH/q2oW80AMHGDAUTUqySBnqeQ18e/SNi7NOCf3ZkYOzKm3Pqw==",
             "dev": true
         },
         "@webassemblyjs/ast": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "hubl",
     "displayName": "HubSpot VS Code Extension",
     "description": "HubSpot CMS Hub support for VS Code",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "publisher": "HubSpot",
     "engines": {
         "vscode": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     },
     "devDependencies": {
         "@types/node": "^15.12.4",
-        "@types/vscode": "^1.55.0",
+        "@types/vscode": "1.30.0",
         "eslint": "^7.5.0",
         "node-loader": "^2.0.0",
         "prettier": "^2.0.5",

--- a/snippets/man_gen/hubl_custom_module_fields.json
+++ b/snippets/man_gen/hubl_custom_module_fields.json
@@ -486,5 +486,111 @@
       "}"
     ],
     "description": "HubSpot Font Field"
+  },
+  "Style Tab Group": {
+    "prefix": "styleTab.group",
+    "body": [
+      "{",
+      "\"name\": \"${1:style}\",",
+      "\"label\": \"${2:Style}\",",
+      "\"children\": [${3}],",
+      "\"type\": \"group\",",
+      "\"tab\": \"STYLE\"",
+      "}"
+    ],
+    "description": "Style Tab Field Group"
+  },
+  "Alignment Field": {
+    "prefix": "field.alignment",
+    "body": [
+      "{",
+      "\"name\": \"${1:alignment_field}\",",
+      "\"label\": \"${2:Alignment field}\",",
+      "\"required\": false,",
+      "\"locked\": false,",
+      "\"type\": \"boolean\",",
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\",",
+      "\"alignment_direction\": \"${3|HORIZONTAL,VERTICAL,BOTH|}\"",
+      "}"
+    ],
+    "description": "HubSpot Alignment Field"
+  },
+  "Gradient Field": {
+    "prefix": "field.gradient",
+    "body": [
+      "{",
+      "\"name\": \"${1:gradient_field}\",",
+      "\"label\": \"${2:Gradient field}\",",
+      "\"required\": false,",
+      "\"locked\": false,",
+      "\"type\": \"gradient\",",
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\"",
+      "}"
+    ],
+    "description": "HubSpot Gradient Field"
+  },
+  "Spacing Field": {
+    "prefix": "field.spacing",
+    "body": [
+      "{",
+      "\"name\": \"${1:spacing_field}\",",
+      "\"label\": \"${2:Spacing field}\",",
+      "\"required\": false,",
+      "\"locked\": false,",
+      "\"type\": \"spacing\",",
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\"",
+      "}"
+    ],
+    "description": "HubSpot Spacing Field"
+  },
+  "Background Image": {
+    "prefix": "field.backgroundImage",
+    "body": [
+      "{",
+      "\"name\": \"${1:background_image_field}\",",
+      "\"label\": \"${2:Background Image field}\",",
+      "\"required\": false,",
+      "\"locked\": false,",
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\",",
+      "\"type\": \"backgroundimage\"",
+      "}"
+    ],
+    "description": "HubSpot Background Image Field"
+  },
+  "Border Field": {
+    "prefix": "field.border",
+    "body": [
+      "{",
+      "\"name\": \"${1:border_field}\",",
+      "\"label\": \"${2:Border field}\",",
+      "\"required\": false,",
+      "\"locked\": false,",
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\",",
+      "\"type\": \"border\",",
+      "\"allow_custom_border_sides\": ${3|true,false|}",
+      "}"
+    ],
+    "description": "HubSpot Border Field"
+  },
+  "Text Alignment Field": {
+    "prefix": "field.textAlignment",
+    "body": [
+      "{",
+      "\"name\": \"${1:text_alignment_field}\",",
+      "\"label\": \"${2:Text Alignment field}\",",
+      "\"required\": false,",
+      "\"locked\": false,",
+      "\"inline_help_text\": \"\",",
+      "\"help_text\": \"\",",
+      "\"type\": \"textalignment\",",
+      "\"alignment_direction\": \"${3|HORIZONTAL,VERTICAL,BOTH|}\"",
+      "}"
+    ],
+    "description": "HubSpot Text Alignment Field"
   }
 }


### PR DESCRIPTION
Adds snippets for new style fields. These snippets do not include examples of the `default` property since these fields are meant to typically be used as overrides, rather than the source of truth for a style.