### PR TITLE
Move hubl linting out of beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "hubl",
-    "version": "0.11.0",
+    "version": "0.13.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "hubl",
-            "version": "0.11.0",
+            "version": "0.13.0",
             "dependencies": {
                 "@hubspot/cli-lib": "3.0.4",
                 "fs-extra": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -177,6 +177,11 @@
         "configuration": {
             "title": "HubSpot",
             "properties": {
+                "hubspot.beta": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Enable HubSpot VS Code extension beta features\n\n*Note: beta features may require a valid `hubspot.config.yml` file*"
+                },
                 "hubspot.hublLinting": {
                     "type": "boolean",
                     "default": true,

--- a/package.json
+++ b/package.json
@@ -181,6 +181,11 @@
                     "type": "boolean",
                     "default": false,
                     "markdownDescription": "Enable HubSpot VS Code extension beta features\n\n*Note: beta features may require a valid `hubspot.config.yml` file*"
+                },
+                "hubspot.hublLinting": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Enables code linting for HTML+HUBL and CSS+HUBL languages.\n\n*Requires a valid `hubspot.config.yml` file*"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "hubl",
     "displayName": "HubSpot VS Code Extension",
     "description": "HubSpot CMS Hub support for VS Code",
-    "version": "0.11.0",
+    "version": "0.13.0",
     "publisher": "HubSpot",
     "engines": {
         "vscode": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -177,11 +177,6 @@
         "configuration": {
             "title": "HubSpot",
             "properties": {
-                "hubspot.beta": {
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Enable HubSpot VS Code extension beta features\n\n*Note: beta features may require a valid `hubspot.config.yml` file*"
-                },
                 "hubspot.hublLinting": {
                     "type": "boolean",
                     "default": true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,30 +69,28 @@ async function activate(context: vscode.ExtensionContext) {
   if (
     vscode.workspace
       .getConfiguration(EXTENSION_CONFIG_NAME)
-      .get(EXTENSION_CONFIG_KEYS.BETA)
+      .get(EXTENSION_CONFIG_KEYS.HUBL_LINTING)
   ) {
     enableLinting();
-  } else {
-    notifyBeta(context);
   }
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration(async (e) => {
       if (
         e.affectsConfiguration(
-          `${EXTENSION_CONFIG_NAME}.${EXTENSION_CONFIG_KEYS.BETA}`
+          `${EXTENSION_CONFIG_NAME}.${EXTENSION_CONFIG_KEYS.HUBL_LINTING}`
         )
       ) {
         if (
           vscode.workspace
             .getConfiguration(EXTENSION_CONFIG_NAME)
-            .get(EXTENSION_CONFIG_KEYS.BETA)
+            .get(EXTENSION_CONFIG_KEYS.HUBL_LINTING)
         ) {
           enableLinting();
-          await trackAction('beta-enabled');
+          await trackAction('linting-enabled');
         } else {
           disableLinting();
-          await trackAction('beta-disabled');
+          await trackAction('linting-disabled');
         }
       }
     })

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -22,6 +22,7 @@ const EXTENSION_CONFIG_NAME = 'hubspot';
 
 const EXTENSION_CONFIG_KEYS = {
   BETA: 'beta',
+  HUBL_LINTING: 'hublLinting',
 };
 
 const GLOBAL_STATE_KEYS = {


### PR DESCRIPTION
Removes the existing `hubspot.beta` setting and introduces `hubspot.hublLinting`, which is turned on by default.