### PR TITLE
Don't package node_modules folder

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,3 +7,4 @@ vsc-extension-quickstart.md
 generate.js
 LICENSE
 scripts/**
+node_modules/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "hubl",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "hubl",
-            "version": "0.15.0",
+            "version": "0.16.0",
             "dependencies": {
                 "@hubspot/cli-lib": "^4.1.3",
                 "fs-extra": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "hubl",
     "displayName": "HubSpot VS Code Extension",
     "description": "HubSpot CMS Hub support for VS Code",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "publisher": "HubSpot",
     "engines": {
         "vscode": "^1.30.0"


### PR DESCRIPTION
Cuts the bundle size down from >4k files (14mb) to 38 files (1.5mb)