### PR TITLE
[WIP] Autocomplete for file paths

### DIFF
--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
-
+import * as fs from 'fs';
+import * as path from 'path';
 import { AccountsProvider } from './providers/accountsProvider';
 import { COMMANDS, TREE_DATA } from './constants';
 
@@ -13,4 +14,48 @@ export const initializeProviders = (context: vscode.ExtensionContext) => {
     })
   );
   vscode.window.registerTreeDataProvider(TREE_DATA.ACCOUNTS, accountProvider);
+
+  const filePathHandler = {
+    provideCompletionItems(
+      document: vscode.TextDocument,
+      position: vscode.Position
+    ) {
+      const linePrefix = document
+        .lineAt(position)
+        .text.substr(0, position.character);
+      if (!linePrefix.endsWith("include '")) {
+        return undefined;
+      }
+      const files: vscode.CompletionItem[] = [];
+      try {
+        const filePath = document.uri.fsPath;
+        const fileDir = path.dirname(filePath);
+        fs.readdirSync(fileDir).forEach((file) => {
+          files.push(
+            new vscode.CompletionItem(
+              `./${file}`,
+              vscode.CompletionItemKind.File
+            )
+          );
+        });
+      } catch (e) {
+        console.log('err', e);
+      }
+      return files;
+    },
+    // This is triggered when selecting an option- may not need this
+    //@ts-ignore
+    resolveCompletionItem(item) {
+      console.log(item);
+    },
+  };
+
+  context.subscriptions.push(
+    vscode.languages.registerCompletionItemProvider(
+      'html-hubl',
+      //@ts-ignore
+      filePathHandler,
+      "'"
+    )
+  );
 };


### PR DESCRIPTION
Autocomplete for file paths!
![image](https://user-images.githubusercontent.com/9009552/205387598-d7beb371-593c-49fc-b96e-911b80da22c2.png)

Super-POC stage but it looks very doable so I'll be cleaning this up and pushing forward on it.

This will apply to these HubL tags/params:
- `include`
- `import`
- ` module path=""` - should also support built-in module paths
- ... tbd 
