### PR TITLE
[POC] View remote files

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,6 +253,11 @@
                     "id": "hubspot.treedata.quickLinks",
                     "name": "Quick Links"
                 }
+                ,
+                {
+                    "id": "hubspot.treedata.remoteFs",
+                    "name": "Remote FS"
+                }
             ]
         },
         "viewsWelcome": [

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -60,6 +60,7 @@ export const EVENTS = {
 export const TREE_DATA = {
   ACCOUNTS: 'hubspot.treedata.accounts',
   QUICK_LINKS: 'hubspot.treedata.quickLinks',
+  REMOTE: 'hubspot.treedata.remoteFs',
 };
 
 export const POLLING_INTERVALS = {

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -2,11 +2,13 @@ import * as vscode from 'vscode';
 
 import { AccountsProvider } from './providers/accounts';
 import { QuickLinksProvider } from './providers/quickLinks';
+import { RemoteFsProvider } from './providers/remoteFs';
 import { COMMANDS, TREE_DATA } from './constants';
 
 export const initializeProviders = (context: vscode.ExtensionContext) => {
   const accountProvider = new AccountsProvider();
   const quickLinksProvider = new QuickLinksProvider();
+  const remoteFsProvider = new RemoteFsProvider();
 
   context.subscriptions.push(
     vscode.commands.registerCommand(COMMANDS.ACCOUNTS_REFRESH, () => {
@@ -19,4 +21,5 @@ export const initializeProviders = (context: vscode.ExtensionContext) => {
     TREE_DATA.QUICK_LINKS,
     quickLinksProvider
   );
+  vscode.window.registerTreeDataProvider(TREE_DATA.REMOTE, remoteFsProvider);
 };

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -3,12 +3,16 @@ import * as vscode from 'vscode';
 import { AccountsProvider } from './providers/accounts';
 import { QuickLinksProvider } from './providers/quickLinks';
 import { RemoteFsProvider } from './providers/remoteFs';
+import { RemoteFileProvider } from './providers/remoteFileProvider';
 import { COMMANDS, TREE_DATA } from './constants';
 
 export const initializeProviders = (context: vscode.ExtensionContext) => {
   const accountProvider = new AccountsProvider();
   const quickLinksProvider = new QuickLinksProvider();
   const remoteFsProvider = new RemoteFsProvider();
+  const remoteFileProvider = RemoteFileProvider;
+
+  const scheme = 'hubl';
 
   context.subscriptions.push(
     vscode.commands.registerCommand(COMMANDS.ACCOUNTS_REFRESH, () => {
@@ -16,6 +20,13 @@ export const initializeProviders = (context: vscode.ExtensionContext) => {
       accountProvider.refresh();
     })
   );
+  context.subscriptions.push(
+    vscode.workspace.registerTextDocumentContentProvider(
+      scheme,
+      remoteFileProvider
+    )
+  );
+
   vscode.window.registerTreeDataProvider(TREE_DATA.ACCOUNTS, accountProvider);
   vscode.window.registerTreeDataProvider(
     TREE_DATA.QUICK_LINKS,

--- a/src/lib/providers/remoteFileProvider.ts
+++ b/src/lib/providers/remoteFileProvider.ts
@@ -1,0 +1,22 @@
+import * as vscode from 'vscode';
+const { download } = require('@hubspot/cli-lib/api/fileMapper');
+const { getPortalId } = require('@hubspot/cli-lib');
+
+export const RemoteFileProvider = new (class
+  implements vscode.TextDocumentContentProvider
+{
+  onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
+  onDidChange = this.onDidChangeEmitter.event;
+
+  async provideTextDocumentContent(
+    uri: vscode.Uri
+  ): Promise<string | undefined> {
+    const filepath = uri.toString().split(':')[1];
+    try {
+      const file = await download(getPortalId(), `/${filepath}`);
+      return file.source;
+    } catch (e) {
+      console.log(e);
+    }
+  }
+})();

--- a/src/lib/providers/remoteFs.ts
+++ b/src/lib/providers/remoteFs.ts
@@ -1,0 +1,49 @@
+import * as vscode from 'vscode';
+import { QuickLink, GetDirectoryContentsByPath } from '../types';
+import { getDirectoryContentsByPath } from '@hubspot/cli-lib/api/fileMapper';
+
+export class RemoteFsProvider implements vscode.TreeDataProvider<QuickLink> {
+  getTreeItem(q: QuickLink): vscode.TreeItem {
+    return new QuickLinkTreeItem(q.label, vscode.Uri.parse(q.url));
+  }
+
+  async getChildren(): Promise<QuickLink[]> {
+    //@ts-ignore
+    const x: GetDirectoryContentsByPath = await getDirectoryContentsByPath();
+    return Promise.resolve([
+      {
+        label: 'Fetch',
+        url: 'https://developers.hubspot.com/docs/cms/developer-reference/local-development-cli#fetch',
+      },
+      {
+        label: 'Upload',
+        url: 'https://developers.hubspot.com/docs/cms/developer-reference/local-development-cli#upload',
+      },
+      {
+        label: 'Watch',
+        url: 'https://developers.hubspot.com/docs/cms/developer-reference/local-development-cli#watch',
+      },
+      {
+        label: 'Remove',
+        url: 'https://developers.hubspot.com/docs/cms/developer-reference/local-development-cli#remove',
+      },
+    ]);
+  }
+}
+
+export class QuickLinkTreeItem extends vscode.TreeItem {
+  constructor(
+    public readonly label: string,
+    public readonly resourceUri: vscode.Uri
+  ) {
+    super(label, vscode.TreeItemCollapsibleState.None);
+    this.tooltip = `Open link: ${resourceUri.toString()}`;
+    this.iconPath = new vscode.ThemeIcon('link-external');
+    this.contextValue = 'link';
+    this.command = {
+      command: 'vscode.open',
+      title: '',
+      arguments: [resourceUri],
+    };
+  }
+}

--- a/src/lib/providers/remoteFs.ts
+++ b/src/lib/providers/remoteFs.ts
@@ -1,44 +1,57 @@
 import * as vscode from 'vscode';
-import { QuickLink, GetDirectoryContentsByPath } from '../types';
-import { getDirectoryContentsByPath } from '@hubspot/cli-lib/api/fileMapper';
+import { FileLink, GetDirectoryContentsByPath } from '../types';
+import { getDefaultPortalFromConfig } from '../helpers';
 
-export class RemoteFsProvider implements vscode.TreeDataProvider<QuickLink> {
-  getTreeItem(q: QuickLink): vscode.TreeItem {
-    return new QuickLinkTreeItem(q.label, vscode.Uri.parse(q.url));
+const {
+  getDirectoryContentsByPath,
+} = require('@hubspot/cli-lib/api/fileMapper');
+const { getPortalId } = require('@hubspot/cli-lib');
+const { FOLDER_DOT_EXTENSIONS } = require('@hubspot/cli-lib/lib/constants');
+
+function isPathFolder(path: string) {
+  const splitPath = path.split('/');
+  const fileOrFolderName = splitPath[splitPath.length - 1];
+  const splitName = fileOrFolderName.split('.');
+
+  if (
+    splitName.length > 1 &&
+    FOLDER_DOT_EXTENSIONS.indexOf(splitName[1]) === -1
+  ) {
+    return false;
   }
 
-  async getChildren(): Promise<QuickLink[]> {
+  return true;
+}
+export class RemoteFsProvider implements vscode.TreeDataProvider<FileLink> {
+  getTreeItem(q: FileLink): vscode.TreeItem {
+    return new QuickLinkTreeItem(q.label, vscode.Uri.parse(q.url), q.icon);
+  }
+
+  async getChildren(): Promise<FileLink[]> {
     //@ts-ignore
-    const x: GetDirectoryContentsByPath = await getDirectoryContentsByPath();
-    return Promise.resolve([
-      {
-        label: 'Fetch',
-        url: 'https://developers.hubspot.com/docs/cms/developer-reference/local-development-cli#fetch',
-      },
-      {
-        label: 'Upload',
-        url: 'https://developers.hubspot.com/docs/cms/developer-reference/local-development-cli#upload',
-      },
-      {
-        label: 'Watch',
-        url: 'https://developers.hubspot.com/docs/cms/developer-reference/local-development-cli#watch',
-      },
-      {
-        label: 'Remove',
-        url: 'https://developers.hubspot.com/docs/cms/developer-reference/local-development-cli#remove',
-      },
-    ]);
+    const directoryContents: GetDirectoryContentsByPath =
+      await getDirectoryContentsByPath(getPortalId(), '/');
+    //@ts-ignore
+    const fileOrFolderList = directoryContents.children.map((f) => {
+      return {
+        label: f,
+        url: `hubl:${f}`,
+        icon: isPathFolder(f) ? 'symbol-folder' : 'file-code',
+      };
+    });
+    return Promise.resolve(fileOrFolderList);
   }
 }
 
 export class QuickLinkTreeItem extends vscode.TreeItem {
   constructor(
     public readonly label: string,
-    public readonly resourceUri: vscode.Uri
+    public readonly resourceUri: vscode.Uri,
+    public readonly icon: string
   ) {
     super(label, vscode.TreeItemCollapsibleState.None);
     this.tooltip = `Open link: ${resourceUri.toString()}`;
-    this.iconPath = new vscode.ThemeIcon('link-external');
+    this.iconPath = new vscode.ThemeIcon(icon);
     this.contextValue = 'link';
     this.command = {
       command: 'vscode.open',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,3 +28,7 @@ export interface QuickLink {
   label: string;
   url: string;
 }
+
+export interface GetDirectoryContentsByPath {
+  any: any;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,6 +28,11 @@ export interface QuickLink {
   label: string;
   url: string;
 }
+export interface FileLink {
+  label: string;
+  url: string;
+  icon: string;
+}
 
 export interface GetDirectoryContentsByPath {
   any: any;


### PR DESCRIPTION
I was curious to dig into some of the viewTree / file handling stuff and put together this POC that lists remote files from the design manager and allows you to view them read-only: 
<img width="1461" alt="image" src="https://user-images.githubusercontent.com/9009552/205774240-38fe4ec3-41f3-446a-8c0e-c9fede52ebde.png">
