### PR TITLE
Fix bug when resolving shallow relative paths

### DIFF
--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -47,8 +47,7 @@ const isFileInWorkspace = (error: any) => {
   if (error.category === 'MODULE_NOT_FOUND') {
     filePath = filePath + '.module';
   }
-
-  return fs.existsSync(path.resolve(dirToActiveFile, filePath));
+  return fs.existsSync(path.normalize(filePath));
 };
 
 const clearValidation = (document: any, collection: any) => {
@@ -76,6 +75,7 @@ const getTemplateType = (document: any) => {
         getAnnotationValue(ANNOTATION_KEYS.isAvailableForNewContent) != 'false',
       tempalate_type:
         TEMPLATE_TYPES[getAnnotationValue(ANNOTATION_KEYS.templateType)],
+      template_path: document.uri.path,
     };
   }
   if (isModuleHTMLFile(document.fileName)) {


### PR DESCRIPTION
When referencing a file within the same directory by relative path, the extension was incorrectly presenting an error that the file could not be found:
![image](https://user-images.githubusercontent.com/9009552/207164418-d961c939-536c-444d-9f91-171c5fdbd4f6.png)

If you notice, the file BE assumes that this path is at the root level because we're not passing a `template_path` value along with the file source.

This PR adds that `template_path`, so all file paths returned from the BE are not absolute paths based on the user's local FS. This doesn't affect any linting on the BE and let's the extension do a proper check to see if the file exists:

![image](https://user-images.githubusercontent.com/9009552/207164171-d63523e8-4b4f-4dbf-9ad6-7e0773b79ec3.png)

![image](https://user-images.githubusercontent.com/9009552/207164907-aebab9e7-6ee0-48f0-87c6-a27ac4190a27.png)

