### PR TITLE
Module creation fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -342,7 +342,7 @@
         ]
     },
     "dependencies": {
-        "@hubspot/cli-lib": "^4.1.4",
+        "@hubspot/cli-lib": "^4.1.5",
         "compare-versions": "^5.0.1",
         "fs-extra": "^9.0.1",
         "js-yaml": "^4.1.0",

--- a/src/lib/fileHelpers.ts
+++ b/src/lib/fileHelpers.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 const { createFunction } = require('@hubspot/cli-lib/functions');
-const { downloadGitHubRepoContentsAtPath } = require('@hubspot/cli-lib/github');
+const { downloadGitHubRepoContents } = require('@hubspot/cli-lib/github');
 
 const copySampleFunctionFilesToFolder = (folderPath: string) => {
   const { dir, base } = path.parse(folderPath);
@@ -69,11 +69,10 @@ export const convertFolderToModule = (
             edit.renameFile(e.files[0], Uri.file(uniqueModulePath));
 
             workspace.applyEdit(edit).then(async () => {
-              await downloadGitHubRepoContentsAtPath(
-                uniqueModulePath,
+              await downloadGitHubRepoContents(
                 'hubspot-cli',
-                // TODO - Update to packages/cli-assets/defaults/Sample.module
-                'packages/cli-lib/defaults/Sample.module'
+                'packages/cli-assets/cms/modules/Sample.module',
+                uniqueModulePath
               );
               resolve(edit);
             });

--- a/src/lib/fileHelpers.ts
+++ b/src/lib/fileHelpers.ts
@@ -69,10 +69,10 @@ export const convertFolderToModule = (
             edit.renameFile(e.files[0], Uri.file(uniqueModulePath));
 
             workspace.applyEdit(edit).then(async () => {
-              console.log('uniqueModulePath: ', uniqueModulePath);
               await downloadGitHubRepoContentsAtPath(
                 uniqueModulePath,
                 'hubspot-cli',
+                // TODO - Update to packages/cli-assets/defaults/Sample.module
                 'packages/cli-lib/defaults/Sample.module'
               );
               resolve(edit);

--- a/src/lib/fileHelpers.ts
+++ b/src/lib/fileHelpers.ts
@@ -1,21 +1,9 @@
 import { workspace, FileWillCreateEvent, Uri, WorkspaceEdit } from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-const { createModule } = require('@hubspot/cli-lib/modules');
-const { createFunction } = require('@hubspot/cli-lib/functions');
 
-const copySampleModuleFilesToFolder = (folderPath: string) => {
-  return createModule(
-    {
-      moduleLabel: '',
-      contentTypes: [],
-      global: false,
-    },
-    '',
-    folderPath,
-    { allowExistingDir: true }
-  );
-};
+const { createFunction } = require('@hubspot/cli-lib/functions');
+const { downloadGitHubRepoContentsAtPath } = require('@hubspot/cli-lib/github');
 
 const copySampleFunctionFilesToFolder = (folderPath: string) => {
   const { dir, base } = path.parse(folderPath);
@@ -80,8 +68,13 @@ export const convertFolderToModule = (
 
             edit.renameFile(e.files[0], Uri.file(uniqueModulePath));
 
-            workspace.applyEdit(edit).then(() => {
-              copySampleModuleFilesToFolder(uniqueModulePath);
+            workspace.applyEdit(edit).then(async () => {
+              console.log('uniqueModulePath: ', uniqueModulePath);
+              await downloadGitHubRepoContentsAtPath(
+                uniqueModulePath,
+                'hubspot-cli',
+                'packages/cli-lib/defaults/Sample.module'
+              );
               resolve(edit);
             });
           }

--- a/src/lib/fileHelpers.ts
+++ b/src/lib/fileHelpers.ts
@@ -70,8 +70,8 @@ export const convertFolderToModule = (
 
             workspace.applyEdit(edit).then(async () => {
               await downloadGitHubRepoContents(
-                'hubspot-cli',
-                'packages/cli-assets/cms/modules/Sample.module',
+                'cms-sample-assets',
+                'modules/Sample.module',
                 uniqueModulePath
               );
               resolve(edit);


### PR DESCRIPTION
The assets needed to populate a created module are not available as part of the webpack bundle.
`@hubspot/cli-lib/defaults/Sample.module/...`

This PR works alongside a PR to the CLI (https://github.com/HubSpot/hubspot-cli/pull/792) that will move assets to a new package and create helper functions to download files from that package on github.

/cc @anthmatic @jsines @TanyaScales 