### PR TITLE
Don't enable extension if workspace is empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -301,20 +301,22 @@
                 {
                     "id": "hubspot.treedata.accounts",
                     "name": "Accounts",
-                    "when": "hubspot.configPath"
+                    "when": "!workbench.explorer.emptyView.active && hubspot.configPath"
                 },
                 {
                     "id": "hubspot.viewsWelcome.accountAuth",
-                    "name": "Authentication"
+                    "name": "Authentication",
+                    "when": "!workbench.explorer.emptyView.active"
                 },
                 {
                     "id": "hubspot.viewsWelcome.tools",
                     "name": "Tools",
-                    "when": "hubspot.versionChecksComplete && hubspot.terminal.versions.installed.npm && !hubspot.terminal.versions.installed.hs || hubspot.updateAvailableForCLI"
+                    "when": "!workbench.explorer.emptyView.active && hubspot.versionChecksComplete && hubspot.terminal.versions.installed.npm && !hubspot.terminal.versions.installed.hs || hubspot.updateAvailableForCLI"
                 },
                 {
                     "id": "hubspot.treedata.helpAndFeedback",
-                    "name": "Help & Feedback"
+                    "name": "Help & Feedback",
+                    "when": "!workbench.explorer.emptyView.active"
                 }
             ]
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext } from 'vscode';
+import { ExtensionContext, workspace } from 'vscode';
 
 import { getRootPath } from './lib/helpers';
 import { registerCommands } from './lib/commands';
@@ -12,6 +12,8 @@ import { initializeTracking, trackEvent } from './lib/tracking';
 import { TRACKED_EVENTS } from './lib/constants';
 
 export const activate = async (context: ExtensionContext) => {
+  if (!workspace.workspaceFolders) return;
+
   initializeTracking(context);
   await trackEvent(TRACKED_EVENTS.ACTIVATE);
   console.log(


### PR DESCRIPTION
I noticed an error if you opened VS Code with no active folders:
![image](https://user-images.githubusercontent.com/9009552/209407889-6b82e397-4bdd-4d2c-a0d4-b230cbccfbb6.png)


After this change the extension will not initialize or show the `ActivityBar` if there is no open folder/file:
![image](https://user-images.githubusercontent.com/9009552/209407736-c275b0b5-4ea1-4311-b5a5-4209634adbdf.png)