### PR TITLE
Updated node version when running github build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
           node-version: 16.x
       - name: Install deps
         run: |
-          yarn install
+          npm install
       - name: Lint
         run: |
-          yarn lint
+          npm run lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,14 +5,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
-    - name: Install deps
-      run: |
+      - uses: actions/checkout@v1
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: Install deps
+        run: |
           yarn install
-    - name: Lint
-      run: |
+      - name: Lint
+        run: |
           yarn lint


### PR DESCRIPTION
The github build action is encountering an error...

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/setup-node@v1
```

This updates the node version to 16 to fix this.

EDIT: Also switched to using `npm` from `yarn`