### PR TITLE
Extension can be activated and opened when no workspace folder is open

### DIFF
--- a/package.json
+++ b/package.json
@@ -389,6 +389,11 @@
         "views": {
             "hubspot-explorer": [
                 {
+                    "id": "hubspot.viewsWelcome.noFolderOpened",
+                    "name": "No Folder Opened",
+                    "when": "workbench.explorer.emptyView.active"
+                },
+                {
                     "id": "hubspot.treedata.accounts",
                     "name": "Accounts",
                     "when": "!workbench.explorer.emptyView.active && hubspot.configPath"
@@ -401,13 +406,13 @@
                 {
                     "id": "hubspot.viewsWelcome.tools",
                     "name": "Tools",
-                    "when": "!workbench.explorer.emptyView.active && hubspot.versionChecksComplete && hubspot.terminal.versions.installed.npm && !hubspot.terminal.versions.installed.hs || hubspot.updateAvailableForCLI"
+                    "when": "hubspot.versionChecksComplete && hubspot.terminal.versions.installed.npm && !hubspot.terminal.versions.installed.hs || hubspot.updateAvailableForCLI"
                 },
                 {
                     "id": "hubspot.treedata.helpAndFeedback",
-                    "name": "Help & Feedback",
-                    "when": "!workbench.explorer.emptyView.active"
+                    "name": "Help & Feedback"
                 }
+
             ]
         },
         "viewsWelcome": [
@@ -430,6 +435,11 @@
                 "view": "hubspot.viewsWelcome.tools",
                 "contents": "An update is available for the [HubSpot CLI](https://developers.hubspot.com/docs/cms/developer-reference/local-development-cli). \n[Update CLI](command:hubspot.hs.update)",
                 "when": "hubspot.updateAvailableForCLI"
+            },
+            {
+                "view": "hubspot.viewsWelcome.noFolderOpened",
+                "contents": "You have not yet opened a folder.\n[Open Folder](command:workbench.action.files.openFileFolder)\nYou can clone a repository locally.\n[Clone Repository](command:git.clone)\nTo learn more about how to use git and source control in VS Code [read out docs](https://code.visualstudio.com/docs/sourcecontrol/overview).",
+                "when": "workbench.explorer.emptyView.active"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -438,7 +438,7 @@
             },
             {
                 "view": "hubspot.viewsWelcome.noFolderOpened",
-                "contents": "You have not yet opened a folder.\n[Open Folder](command:workbench.action.files.openFileFolder)\nYou can clone a repository locally.\n[Clone Repository](command:git.clone)\nTo learn more about how to use git and source control in VS Code [read out docs](https://code.visualstudio.com/docs/sourcecontrol/overview).",
+                "contents": "You have not yet opened a folder.\n[Open Folder](command:workbench.action.files.openFileFolder)\nYou can clone a repository locally.\n[Clone Repository](command:git.clone)\nTo learn more about how to use git and source control in VS Code [read our docs](https://code.visualstudio.com/docs/sourcecontrol/overview).",
                 "when": "workbench.explorer.emptyView.active"
             }
         ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,8 +16,6 @@ import { initializeTracking, trackEvent } from './lib/tracking';
 import { initializeGlobalState } from './lib/globalState';
 
 export const activate = async (context: ExtensionContext) => {
-  if (!workspace.workspaceFolders) return;
-
   initializeTracking(context);
   await trackEvent(TRACKED_EVENTS.ACTIVATE);
   console.log(
@@ -36,5 +34,8 @@ export const activate = async (context: ExtensionContext) => {
   initializeTerminal();
   initializeStatusBar(context);
 
-  initializeConfig(rootPath);
+  if (rootPath) {
+    initializeConfig(rootPath);
+  }
+  // TODO: Subscribe to config creation/workspace open?
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,5 +37,4 @@ export const activate = async (context: ExtensionContext) => {
   if (rootPath) {
     initializeConfig(rootPath);
   }
-  // TODO: Subscribe to config creation/workspace open?
 };

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -11,10 +11,12 @@ import { registerCommands as registerTerminalCommands } from './commands/termina
 
 export const registerCommands = (
   context: ExtensionContext,
-  rootPath: string
+  rootPath: string | undefined
 ) => {
+  if (rootPath) {
+    registerAuthCommands(context, rootPath);
+  }
   registerAccountCommands(context);
-  registerAuthCommands(context, rootPath);
   registerConfigCommands(context);
   registerGlobalStateCommands(context);
   registerModuleCommands(context);

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -7,7 +7,7 @@ export const getRootPath = () => {
   const workspaceFolders = workspace.workspaceFolders;
 
   if (!workspaceFolders || workspaceFolders.length < 1) {
-    throw new Error('No workspace folder found.');
+    return;
   }
   return workspaceFolders[0].uri.path;
 };


### PR DESCRIPTION
The extension `activitybar` item was disabled when no workspace folder is open (`!workbench.explorer.emptyView.active`). This PR allows the extension to be activated and opened and adds a notification section to notify the user that they need to open a folder.

The content of the section mimics the one displayed in the `explorer` activity bar item provided with VSCode. The "Open Folder" button opens the file picker and reloads the extension when a folder is selected/opened. The "Clone Repository" button runs the "Git: Clone"(`git.clone`) command, which will allow a repository to be opened instead.

![image](https://user-images.githubusercontent.com/6472448/213782834-603f1b24-de44-4465-82c8-36f278fccc12.png)


_Note:_ The ability to mirror the `workbench.explorer.emptyView` by embedding it into our menu does not work. I filed a bug for this in vscode -> https://github.com/microsoft/vscode/issues/171859

Once this bug is fixed, we can remove our `hubspot.viewsWelcome.noFolderOpened` welcome view in favor of embedding `workbench.explorer.emptyView`.
