### PR TITLE
Prevent error if hs already exists in the user's bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -412,7 +412,6 @@
                     "id": "hubspot.treedata.helpAndFeedback",
                     "name": "Help & Feedback"
                 }
-
             ]
         },
         "viewsWelcome": [

--- a/src/lib/commands/terminal.ts
+++ b/src/lib/commands/terminal.ts
@@ -42,7 +42,7 @@ export const registerCommands = (context: ExtensionContext) => {
       ).includes('@hubspot/cms-cli');
       if (hsLegacyInstalled) {
         const selection = await window.showWarningMessage(
-          'The legacy Hubspot CLI (@hubspot/cms-cli) must be removed to update. Continue?',
+          'The legacy Hubspot CLI (@hubspot/cms-cli) will be removed to update. Continue?',
           ...['Okay', 'Cancel']
         );
         if (!selection || selection === 'Cancel') {

--- a/src/lib/commands/terminal.ts
+++ b/src/lib/commands/terminal.ts
@@ -37,6 +37,20 @@ export const registerCommands = (context: ExtensionContext) => {
       );
       terminal.show();
 
+      const hsLegacyInstalled: boolean = (
+        await runTerminalCommand(`npm list -g`)
+      ).includes('@hubspot/cms-cli');
+      if (hsLegacyInstalled) {
+        const selection = await window.showWarningMessage(
+          'The legacy Hubspot CLI (@hubspot/cms-cli) must be removed to update. Continue?',
+          ...['Okay', 'Cancel']
+        );
+        if (!selection || selection === 'Cancel') {
+          terminal.dispose();
+          return;
+        }
+      }
+
       const hubspotUpdatedPoll = setInterval(async () => {
         const hsVersion = await commands.executeCommand(
           COMMANDS.VERSION_CHECK.HS

--- a/src/lib/commands/terminal.ts
+++ b/src/lib/commands/terminal.ts
@@ -116,7 +116,7 @@ export const registerCommands = (context: ExtensionContext) => {
       return hsVersion;
     })
   );
-  
+
   context.subscriptions.push(
     commands.registerCommand(COMMANDS.VERSION_CHECK.NPM, async () => {
       const npmVersion = await checkTerminalCommandVersion('npm');

--- a/src/lib/commands/terminal.ts
+++ b/src/lib/commands/terminal.ts
@@ -51,7 +51,7 @@ export const registerCommands = (context: ExtensionContext) => {
       }, POLLING_INTERVALS.FAST);
 
       terminal.sendText(
-        "echo 'Updating the HubSpot CLI.' && npm i -g @hubspot/cli@latest && echo 'Update complete. You can now close this terminal window.'"
+        "echo 'Updating the HubSpot CLI.' && npm remove -g @hubspot/cms-cli && npm i -g @hubspot/cli@latest && echo 'Update complete. You can now close this terminal window.'"
       );
     })
   );
@@ -116,7 +116,7 @@ export const registerCommands = (context: ExtensionContext) => {
       return hsVersion;
     })
   );
-
+  
   context.subscriptions.push(
     commands.registerCommand(COMMANDS.VERSION_CHECK.NPM, async () => {
       const npmVersion = await checkTerminalCommandVersion('npm');


### PR DESCRIPTION
If the old cms-cli was already installed on a user's machine, and the extension runs npm commands to install hubspot-cli, npm will crash in the process because it will not overwrite the existing executable without --force.

This change adds a command to remove the legacy CLI during the update process to prevent this error.