### PR TITLE
Win32 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the HubSpot VS Code extension will be documented in this file.
 
+## [1.0.2]
+
+- Fixed issues preventing the extension from function properly on Windows machines.
+
 ## [1.0.1]
 
 - Fixed issue where CLI update flow would break when user had a legacy CLI version installed 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "hubl",
     "displayName": "HubSpot",
     "description": "HubSpot CMS Hub support for VS Code",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "publisher": "HubSpot",
     "engines": {
         "vscode": "^1.63.0"

--- a/src/lib/commands/terminal.ts
+++ b/src/lib/commands/terminal.ts
@@ -23,9 +23,10 @@ export const registerCommands = (context: ExtensionContext) => {
         }
       }, POLLING_INTERVALS.FAST);
 
-      const cmd = process.platform === 'win32'
-        ? "echo 'Installing the HubSpot CLI.' & npm i -g @hubspot/cli@latest & echo 'Installation complete. You can now close this terminal window.'"
-        : "echo 'Installing the HubSpot CLI.' && npm i -g @hubspot/cli@latest && echo 'Installation complete. You can now close this terminal window.'";
+      const cmd =
+        process.platform === 'win32'
+          ? "echo 'Installing the HubSpot CLI.' & npm i -g @hubspot/cli@latest & echo 'Installation complete. You can now close this terminal window.'"
+          : "echo 'Installing the HubSpot CLI.' && npm i -g @hubspot/cli@latest && echo 'Installation complete. You can now close this terminal window.'";
       terminal.sendText(cmd);
     })
   );
@@ -65,9 +66,10 @@ export const registerCommands = (context: ExtensionContext) => {
         }
       }, POLLING_INTERVALS.FAST);
 
-      const cmd = process.platform === 'win32'
-        ? "echo 'Updating the HubSpot CLI.' & npm uninstall -g @hubspot/cms-cli & npm i -g @hubspot/cli@latest & echo 'Update complete. You can now close this terminal window.'"
-        : "echo 'Updating the HubSpot CLI.' && npm uninstall -g @hubspot/cms-cli && npm i -g @hubspot/cli@latest && echo 'Update complete. You can now close this terminal window.'";
+      const cmd =
+        process.platform === 'win32'
+          ? "echo 'Updating the HubSpot CLI.' & npm uninstall -g @hubspot/cms-cli & npm i -g @hubspot/cli@latest & echo 'Update complete. You can now close this terminal window.'"
+          : "echo 'Updating the HubSpot CLI.' && npm uninstall -g @hubspot/cms-cli && npm i -g @hubspot/cli@latest && echo 'Update complete. You can now close this terminal window.'";
       terminal.sendText(cmd);
     })
   );
@@ -75,9 +77,10 @@ export const registerCommands = (context: ExtensionContext) => {
   context.subscriptions.push(
     commands.registerCommand(COMMANDS.VERSION_CHECK.HS_LATEST, async () => {
       const hsVersion = (await runTerminalCommand('hs --version')).trim();
-      const cmd = process.platform === 'win32'
-        ? `npm info @hubspot/cli@latest | findstr "latest"`
-        : `npm info @hubspot/cli@latest | grep 'latest'`;
+      const cmd =
+        process.platform === 'win32'
+          ? `npm info @hubspot/cli@latest | findstr "latest"`
+          : `npm info @hubspot/cli@latest | grep 'latest'`;
       const nodeLatestLine: string = await runTerminalCommand(cmd);
       const latestHsVersion = nodeLatestLine
         .replace(

--- a/src/lib/commands/terminal.ts
+++ b/src/lib/commands/terminal.ts
@@ -76,7 +76,7 @@ export const registerCommands = (context: ExtensionContext) => {
     commands.registerCommand(COMMANDS.VERSION_CHECK.HS_LATEST, async () => {
       const hsVersion = (await runTerminalCommand('hs --version')).trim();
       const cmd = process.platform === 'win32'
-        ? `npm info @hubspot/cli@latest | findstr 'latest'`
+        ? `npm info @hubspot/cli@latest | findstr "latest"`
         : `npm info @hubspot/cli@latest | grep 'latest'`;
       const nodeLatestLine: string = await runTerminalCommand(cmd);
       const latestHsVersion = nodeLatestLine

--- a/src/lib/commands/terminal.ts
+++ b/src/lib/commands/terminal.ts
@@ -23,9 +23,10 @@ export const registerCommands = (context: ExtensionContext) => {
         }
       }, POLLING_INTERVALS.FAST);
 
-      terminal.sendText(
-        "echo 'Installing the HubSpot CLI.' && npm i -g @hubspot/cli@latest && echo 'Installation complete. You can now close this terminal window.'"
-      );
+      const cmd = process.platform === 'win32'
+        ? "echo 'Installing the HubSpot CLI.' & npm i -g @hubspot/cli@latest & echo 'Installation complete. You can now close this terminal window.'"
+        : "echo 'Installing the HubSpot CLI.' && npm i -g @hubspot/cli@latest && echo 'Installation complete. You can now close this terminal window.'";
+      terminal.sendText(cmd);
     })
   );
 
@@ -64,18 +65,20 @@ export const registerCommands = (context: ExtensionContext) => {
         }
       }, POLLING_INTERVALS.FAST);
 
-      terminal.sendText(
-        "echo 'Updating the HubSpot CLI.' && npm uninstall -g @hubspot/cms-cli && npm i -g @hubspot/cli@latest && echo 'Update complete. You can now close this terminal window.'"
-      );
+      const cmd = process.platform === 'win32'
+        ? "echo 'Updating the HubSpot CLI.' & npm uninstall -g @hubspot/cms-cli & npm i -g @hubspot/cli@latest & echo 'Update complete. You can now close this terminal window.'"
+        : "echo 'Updating the HubSpot CLI.' && npm uninstall -g @hubspot/cms-cli && npm i -g @hubspot/cli@latest && echo 'Update complete. You can now close this terminal window.'";
+      terminal.sendText(cmd);
     })
   );
 
   context.subscriptions.push(
     commands.registerCommand(COMMANDS.VERSION_CHECK.HS_LATEST, async () => {
       const hsVersion = (await runTerminalCommand('hs --version')).trim();
-      const nodeLatestLine: string = await runTerminalCommand(
-        `npm info @hubspot/cli@latest | grep 'latest'`
-      );
+      const cmd = process.platform === 'win32'
+        ? `npm info @hubspot/cli@latest | findstr 'latest'`
+        : `npm info @hubspot/cli@latest | grep 'latest'`;
+      const nodeLatestLine: string = await runTerminalCommand(cmd);
       const latestHsVersion = nodeLatestLine
         .replace(
           // Remove ANSI color styles https://stackoverflow.com/a/29497680

--- a/src/lib/fileHelpers.ts
+++ b/src/lib/fileHelpers.ts
@@ -45,10 +45,7 @@ const buildFileCreateListener = (
   cleanupCallback: Function
 ) => {
   return async (e: FileCreateEvent) => {
-    if (
-      e.files?.length === 1 &&
-      e.files[0].fsPath.startsWith(folderPath)
-    ) {
+    if (e.files?.length === 1 && e.files[0].fsPath.startsWith(folderPath)) {
       cleanupCallback();
       const uniqueFilePath = getUniquePathName(e.files[0].fsPath, extension);
       if (e.files[0].fsPath !== uniqueFilePath) {

--- a/src/lib/fileHelpers.ts
+++ b/src/lib/fileHelpers.ts
@@ -47,7 +47,7 @@ const buildFileCreateListener = (
   return async (e: FileCreateEvent) => {
     if (
       e.files?.length === 1 &&
-      new RegExp(`${folderPath}/.*`).test(e.files[0].fsPath)
+      e.files[0].fsPath.startsWith(folderPath)
     ) {
       cleanupCallback();
       const uniqueFilePath = getUniquePathName(e.files[0].fsPath, extension);
@@ -89,7 +89,7 @@ const buildFolderCreateListener = (
 
           if (
             e.files?.length === 1 &&
-            new RegExp(`${folderPath}/.*`).test(e.files[0].fsPath)
+            e.files[0].fsPath.startsWith(folderPath)
           ) {
             cleanupCallback();
             const uniqueFolderPath = getUniquePathName(

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -34,21 +34,19 @@ export const runTerminalCommand = async (
 ): Promise<string> => {
   return new Promise((resolve, reject) => {
     try {
-      const cmd = process.platform === 'win32'
-        ? `${terminalCommand} & exit`
-        : `${terminalCommand} && exit`;
-      exec(
-        cmd,
-        (error: Error, stdout: string, stderr: string) => {
-          const err = error || stderr;
+      const cmd =
+        process.platform === 'win32'
+          ? `${terminalCommand} & exit`
+          : `${terminalCommand} && exit`;
+      exec(cmd, (error: Error, stdout: string, stderr: string) => {
+        const err = error || stderr;
 
-          if (err) {
-            reject(err);
-          } else {
-            resolve(stdout);
-          }
+        if (err) {
+          reject(err);
+        } else {
+          resolve(stdout);
         }
-      );
+      });
     } catch (e) {
       reject(e);
     }
@@ -60,9 +58,10 @@ export const checkTerminalCommandVersion = async (
 ): Promise<string | undefined> => {
   return new Promise(async (resolve, reject) => {
     try {
-      const cmd = process.platform === 'win32'
-        ? `where ${terminalCommand}`
-        : `which ${terminalCommand}`;
+      const cmd =
+        process.platform === 'win32'
+          ? `where ${terminalCommand}`
+          : `which ${terminalCommand}`;
       const pathOutputMaybe = await runTerminalCommand(cmd);
       if (pathOutputMaybe === `${terminalCommand} not found`) {
         // Command is not installed/found

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -9,7 +9,7 @@ export const getRootPath = () => {
   if (!workspaceFolders || workspaceFolders.length < 1) {
     return;
   }
-  return workspaceFolders[0].uri.path;
+  return workspaceFolders[0].uri.fsPath;
 };
 
 export const getDefaultPortalFromConfig = (config: HubspotConfig) => {
@@ -34,8 +34,11 @@ export const runTerminalCommand = async (
 ): Promise<string> => {
   return new Promise((resolve, reject) => {
     try {
+      const cmd = process.platform === 'win32'
+        ? `${terminalCommand} & exit`
+        : `${terminalCommand} && exit`;
       exec(
-        `${terminalCommand} && exit`,
+        cmd,
         (error: Error, stdout: string, stderr: string) => {
           const err = error || stderr;
 
@@ -57,9 +60,10 @@ export const checkTerminalCommandVersion = async (
 ): Promise<string | undefined> => {
   return new Promise(async (resolve, reject) => {
     try {
-      const pathOutputMaybe = await runTerminalCommand(
-        `which ${terminalCommand}`
-      );
+      const cmd = process.platform === 'win32'
+        ? `where ${terminalCommand}`
+        : `which ${terminalCommand}`;
+      const pathOutputMaybe = await runTerminalCommand(cmd);
       if (pathOutputMaybe === `${terminalCommand} not found`) {
         // Command is not installed/found
         resolve(undefined);

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -82,7 +82,7 @@ export const trackEvent = async (action: string, options?: object) => {
   }
   const accountId = getAccountId();
 
-  await trackUsage(
+  trackUsage(
     'vscode-extension-interaction',
     'INTERACTION',
     {
@@ -91,5 +91,8 @@ export const trackEvent = async (action: string, options?: object) => {
       action,
     },
     accountId
+  ).then(
+    (val: any) => {},
+    (err: any) => { console.error(`trackUsage failed: ${err}`) }
   );
 };

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -93,6 +93,8 @@ export const trackEvent = async (action: string, options?: object) => {
     accountId
   ).then(
     (val: any) => {},
-    (err: any) => { console.error(`trackUsage failed: ${err}`) }
+    (err: any) => {
+      console.error(`trackUsage failed: ${err}`);
+    }
   );
 };


### PR DESCRIPTION
Updates terminal usage and paths for win32 compatibility. 

Also updates tracking to be non-blocking, no longer `await`s it and instead just reports an error when the promise finishes if it fails.