### PR TITLE
fixes #122 – adds validation_error_message to text

### DIFF
--- a/snippets/man_gen/hubl_custom_module_fields.json
+++ b/snippets/man_gen/hubl_custom_module_fields.json
@@ -136,6 +136,7 @@
       "\"required\": false,",
       "\"locked\": false,",
       "\"validation_regex\": \"\",",
+      "\"validation_error_message\": \"\",",
       "\"allow_new_line\": false,",
       "\"show_emoji_picker\": false,",
       "\"type\": \"text\",",


### PR DESCRIPTION
Add `validation_error_message` to text field snippet in `snippets/man_gen/hubl_custom_module_fields.json`