### PR TITLE
remotefs fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "hubl",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "hubl",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "dependencies": {
                 "@hubspot/cli-lib": "^4.1.6",
                 "dayjs": "^1.11.7",

--- a/package.json
+++ b/package.json
@@ -254,6 +254,11 @@
                 "title": "Refresh"
             },
             {
+
+                "command": "hubspot.remoteFs.fetch",
+                "title": "Fetch"
+            },
+            {
                 "command": "hubspot.remoteFs.delete",
                 "title": "Delete"
             }
@@ -328,6 +333,10 @@
                     "command": "hubspot.account.viewPersonalAccessKey",
                     "when": "viewItem == accountTreeItem",
                     "group": "accountTreeItemRightClick@1"
+                },
+                {
+                    "command": "hubspot.remoteFs.fetch",
+                    "when": "viewItem == remoteFsTreeItem"
                 },
                 {
                     "command": "hubspot.remoteFs.delete",

--- a/src/lib/commands/remoteFs.ts
+++ b/src/lib/commands/remoteFs.ts
@@ -1,9 +1,44 @@
-import { ExtensionContext, window, commands } from 'vscode';
+import { ExtensionContext, window, commands, workspace, Uri } from 'vscode';
 import { COMMANDS } from '../constants';
+import { getRootPath } from '../helpers';
 const { deleteFile } = require('@hubspot/cli-lib/api/fileMapper');
+const { downloadFileOrFolder } = require('@hubspot/cli-lib/fileMapper');
 const { getPortalId } = require('@hubspot/cli-lib');
 
 export const registerCommands = (context: ExtensionContext) => {
+  context.subscriptions.push(
+    commands.registerCommand(
+        COMMANDS.REMOTE_FS.FETCH,
+        async (clickedFileLink) => {
+            const fileLinkIsFolder = clickedFileLink.icon === 'symbol-folder';
+            const filePath = fileLinkIsFolder
+                ? clickedFileLink.path
+                : clickedFileLink.url.slice(5);
+            // We use showOpenDialog instead of showSaveDialog because the latter has worse support for this use-case
+            const destPath = await window.showOpenDialog({
+                canSelectFiles: false,
+                canSelectFolders: true,
+                canSelectMany: false,
+                openLabel: "Save",
+                title: "Save Remote File",
+                defaultUri: Uri.from({
+                    scheme: 'file',
+                    path: getRootPath()
+                })
+            });
+            if (destPath === undefined) {
+                return;
+            }
+            console.log(`Saving remote file ${filePath} to filesystem path ${destPath[0].fsPath}`);
+            await downloadFileOrFolder({
+                accountId: getPortalId(),
+                src: filePath,
+                dest: destPath[0].fsPath,
+                options: {}
+            });
+        }
+    )
+  );
   context.subscriptions.push(
     commands.registerCommand(
       COMMANDS.REMOTE_FS.DELETE,

--- a/src/lib/commands/remoteFs.ts
+++ b/src/lib/commands/remoteFs.ts
@@ -28,10 +28,14 @@ export const registerCommands = (context: ExtensionContext) => {
             path: getRootPath(),
           }),
         });
-        if (destPath === undefined) { // User didn't select anything
+        if (destPath === undefined) {
+          // User didn't select anything
           return;
         }
-        const localFilePath = join(destPath[0].fsPath, remoteFilePath.split('/').slice(-1)[0]);
+        const localFilePath = join(
+          destPath[0].fsPath,
+          remoteFilePath.split('/').slice(-1)[0]
+        );
         if (existsSync(localFilePath)) {
           const selection = await window.showWarningMessage(
             `There already exists a file at ${localFilePath}. Overwrite it?`,
@@ -49,7 +53,7 @@ export const registerCommands = (context: ExtensionContext) => {
           src: remoteFilePath,
           dest: localFilePath,
           options: {
-            overwrite: true
+            overwrite: true,
           },
         });
       }

--- a/src/lib/commands/remoteFs.ts
+++ b/src/lib/commands/remoteFs.ts
@@ -42,7 +42,7 @@ export const registerCommands = (context: ExtensionContext) => {
           }
         }
         console.log(
-          `Saving remote file ${remoteFilePath} to filesystem path ${destPath[0].fsPath}`
+          `Saving remote file ${remoteFilePath} to filesystem path ${localFilePath}`
         );
         await downloadFileOrFolder({
           accountId: getPortalId(),

--- a/src/lib/commands/remoteFs.ts
+++ b/src/lib/commands/remoteFs.ts
@@ -8,35 +8,37 @@ const { getPortalId } = require('@hubspot/cli-lib');
 export const registerCommands = (context: ExtensionContext) => {
   context.subscriptions.push(
     commands.registerCommand(
-        COMMANDS.REMOTE_FS.FETCH,
-        async (clickedFileLink) => {
-            const fileLinkIsFolder = clickedFileLink.icon === 'symbol-folder';
-            const filePath = fileLinkIsFolder
-                ? clickedFileLink.path
-                : clickedFileLink.url.slice(5);
-            // We use showOpenDialog instead of showSaveDialog because the latter has worse support for this use-case
-            const destPath = await window.showOpenDialog({
-                canSelectFiles: false,
-                canSelectFolders: true,
-                canSelectMany: false,
-                openLabel: "Save",
-                title: "Save Remote File",
-                defaultUri: Uri.from({
-                    scheme: 'file',
-                    path: getRootPath()
-                })
-            });
-            if (destPath === undefined) {
-                return;
-            }
-            console.log(`Saving remote file ${filePath} to filesystem path ${destPath[0].fsPath}`);
-            await downloadFileOrFolder({
-                accountId: getPortalId(),
-                src: filePath,
-                dest: destPath[0].fsPath,
-                options: {}
-            });
+      COMMANDS.REMOTE_FS.FETCH,
+      async (clickedFileLink) => {
+        const fileLinkIsFolder = clickedFileLink.icon === 'symbol-folder';
+        const filePath = fileLinkIsFolder
+          ? clickedFileLink.path
+          : clickedFileLink.url.slice(5);
+        // We use showOpenDialog instead of showSaveDialog because the latter has worse support for this use-case
+        const destPath = await window.showOpenDialog({
+          canSelectFiles: false,
+          canSelectFolders: true,
+          canSelectMany: false,
+          openLabel: 'Save',
+          title: 'Save Remote File',
+          defaultUri: Uri.from({
+            scheme: 'file',
+            path: getRootPath(),
+          }),
+        });
+        if (destPath === undefined) {
+          return;
         }
+        console.log(
+          `Saving remote file ${filePath} to filesystem path ${destPath[0].fsPath}`
+        );
+        await downloadFileOrFolder({
+          accountId: getPortalId(),
+          src: filePath,
+          dest: destPath[0].fsPath,
+          options: {},
+        });
+      }
     )
   );
   context.subscriptions.push(

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -70,6 +70,7 @@ export const COMMANDS = {
   },
   REMOTE_FS: {
     REFRESH: 'hubspot.remoteFs.refresh',
+    FETCH: 'hubspot.remoteFs.fetch',
     DELETE: 'hubspot.remoteFs.delete',
   },
   VERSION_CHECK: {


### PR DESCRIPTION
Adds fetch command to remote file system view items on right-click: 

![Screenshot 2023-03-07 at 4 37 07 PM](https://user-images.githubusercontent.com/25852903/223558589-0bf85feb-84c2-4bbd-a19d-c24a26e24c67.png)

Which proceeds to open a dialog window to select a location to save the remote file to the local filesystem: 

![Screenshot 2023-03-07 at 4 37 40 PM](https://user-images.githubusercontent.com/25852903/223558683-ecd5c29d-3aa0-4d38-b644-69f1567ad805.png)

When a file is fetched, it will be downloaded to the selected folder.
When a folder is fetched, _it's contents_ will be downloaded to the selected folder. To duplicate a remote folder to the local filesystem, a new folder must be created to store its contents. This behavior is a little quirky, I might play around a bit more and see if we can get it to download the folder itself without needing the user to type in their own file name, but the CLI fetch requires a specificed file path destination as well so the behavior isn't _super_ out of the norm.
