### PR TITLE
Cache remote files

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,7 +251,15 @@
             },
             {
                 "command": "hubspot.remoteFs.refresh",
+                "title": "Cached Refresh"
+            },
+            {
+                "command": "hubspot.remoteFs.hardRefresh",
                 "title": "Refresh"
+            },
+            {
+                "command": "hubspot.remoteFs.invalidateCache",
+                "title": "Invalidate Cache"
             },
             {
 
@@ -345,7 +353,7 @@
             ],
             "view/title": [
                 {
-                    "command": "hubspot.remoteFs.refresh",
+                    "command": "hubspot.remoteFs.hardRefresh",
                     "when": "view == hubspot.treedata.remoteFs"
                 }
             ],
@@ -400,6 +408,14 @@
                 },
                 {
                     "command": "hubspot.account.viewPersonalAccessKey",
+                    "when": "false"
+                },
+                {
+                    "command": "hubspot.remoteFs.refresh",
+                    "when": "false"
+                },
+                {
+                    "command": "hubspot.remoteFs.invalidateCache",
                     "when": "false"
                 }
             ]

--- a/src/lib/commands/remoteFs.ts
+++ b/src/lib/commands/remoteFs.ts
@@ -79,10 +79,13 @@ export const registerCommands = (context: ExtensionContext) => {
         deleteFile(getPortalId(), filePath).then(() => {
           window.showInformationMessage(`Successfully deleted ${filePath}`);
           let parentDirectory = dirname(filePath);
-          if (parentDirectory === '.') { 
+          if (parentDirectory === '.') {
             parentDirectory = '/';
           }
-          commands.executeCommand('hubspot.remoteFs.invalidateCache', parentDirectory);
+          commands.executeCommand(
+            'hubspot.remoteFs.invalidateCache',
+            parentDirectory
+          );
           commands.executeCommand('hubspot.remoteFs.refresh');
         });
       }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -70,6 +70,8 @@ export const COMMANDS = {
   },
   REMOTE_FS: {
     REFRESH: 'hubspot.remoteFs.refresh',
+    HARD_REFRESH: 'hubspot.remoteFs.hardRefresh',
+    INVALIDATE_CACHE: 'hubspot.remoteFs.invalidateCache',
     FETCH: 'hubspot.remoteFs.fetch',
     DELETE: 'hubspot.remoteFs.delete',
   },

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -49,6 +49,18 @@ const initializeTreeDataProviders = (context: ExtensionContext) => {
       remoteFsProvider.refresh();
     })
   );
+  context.subscriptions.push(
+    commands.registerCommand(COMMANDS.REMOTE_FS.HARD_REFRESH, () => {
+      console.log(COMMANDS.REMOTE_FS.HARD_REFRESH);
+      remoteFsProvider.hardRefresh();
+    })
+  );
+  context.subscriptions.push(
+    commands.registerCommand(COMMANDS.REMOTE_FS.INVALIDATE_CACHE, (filePath) => {
+      console.log(COMMANDS.REMOTE_FS.INVALIDATE_CACHE);
+      remoteFsProvider.invalidateCache(filePath)
+    })
+  )
 };
 
 export const initializeProviders = (context: ExtensionContext) => {

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -56,11 +56,14 @@ const initializeTreeDataProviders = (context: ExtensionContext) => {
     })
   );
   context.subscriptions.push(
-    commands.registerCommand(COMMANDS.REMOTE_FS.INVALIDATE_CACHE, (filePath) => {
-      console.log(COMMANDS.REMOTE_FS.INVALIDATE_CACHE);
-      remoteFsProvider.invalidateCache(filePath)
-    })
-  )
+    commands.registerCommand(
+      COMMANDS.REMOTE_FS.INVALIDATE_CACHE,
+      (filePath) => {
+        console.log(COMMANDS.REMOTE_FS.INVALIDATE_CACHE);
+        remoteFsProvider.invalidateCache(filePath);
+      }
+    )
+  );
 };
 
 export const initializeProviders = (context: ExtensionContext) => {

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -30,10 +30,23 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
   > = new EventEmitter<FileLink | undefined | null | void>();
   readonly onDidChangeTreeData: Event<void | FileLink | null | undefined> =
     this._onDidChangeTreeData.event;
+  private remoteFsCache: Map<string, RemoteFsDirectory> = new Map();
 
   refresh(): void {
     this._onDidChangeTreeData.fire();
   }
+
+  hardRefresh(): void {
+    this.remoteFsCache.clear();
+    this.refresh();
+  }
+
+  invalidateCache(filePath: string): void {
+    console.log(`Invalidating cache for ${filePath}`)
+    this.remoteFsCache.delete(filePath);
+    this.refresh();
+  }
+
   getTreeItem(fileLink: FileLink): TreeItem {
     return fileLink.url
       ? new RemoteFsTreeItem(
@@ -51,9 +64,13 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
 
   async getChildren(parent?: FileLink): Promise<FileLink[]> {
     const remoteDirectory: string = parent?.path ? parent.path : '/';
-    const directoryContents: RemoteFsDirectory =
-      await getDirectoryContentsByPath(getPortalId(), remoteDirectory);
-    const fileOrFolderList = directoryContents.children.map((f) => {
+
+    let directoryContents: any = this.remoteFsCache.get(remoteDirectory);
+    if (directoryContents === undefined) {
+      directoryContents = await getDirectoryContentsByPath(getPortalId(), remoteDirectory);
+      this.remoteFsCache.set(remoteDirectory, directoryContents);
+    }
+    const fileOrFolderList = directoryContents.children.map((f: string) => {
       return isPathFolder(f)
         ? {
             label: f,

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -46,7 +46,7 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
     // Invalidate the key itself and all child paths
     for (const key of this.remoteFsCache.keys()) {
       if (key.startsWith(filePath)) {
-        this.remoteFsCache.delete(key)
+        this.remoteFsCache.delete(key);
       }
     }
     this.refresh();

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -42,7 +42,7 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
   }
 
   invalidateCache(filePath: string): void {
-    console.log(`Invalidating cache for ${filePath}`)
+    console.log(`Invalidating cache for ${filePath}`);
     this.remoteFsCache.delete(filePath);
     this.refresh();
   }
@@ -67,7 +67,10 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
 
     let directoryContents: any = this.remoteFsCache.get(remoteDirectory);
     if (directoryContents === undefined) {
-      directoryContents = await getDirectoryContentsByPath(getPortalId(), remoteDirectory);
+      directoryContents = await getDirectoryContentsByPath(
+        getPortalId(),
+        remoteDirectory
+      );
       this.remoteFsCache.set(remoteDirectory, directoryContents);
     }
     const fileOrFolderList = directoryContents.children.map((f: string) => {

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -43,7 +43,12 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
 
   invalidateCache(filePath: string): void {
     console.log(`Invalidating cache for ${filePath}`);
-    this.remoteFsCache.delete(filePath);
+    // Invalidate the key itself and all child paths
+    for (const key of this.remoteFsCache.keys()) {
+      if (key.startsWith(filePath)) {
+        this.remoteFsCache.delete(key)
+      }
+    }
     this.refresh();
   }
 


### PR DESCRIPTION
Working on upload (& got it working pretty well!) but got frustrated by the amount of hard refreshes the remote filesystem view had to do to keep it in sync locally. This should cut back pretty hard on the amount of API calls necessary to keep the system in sync, especially as the amount of files shown in the view grows. Instead of firing a request of every remote folder on refresh (fetch '/', then all children of '/' that are open, then all their children, etc) we store the results and invalidate the parent whenever a file gets deleted. Works much nicer!