### PR TITLE
Remote FS upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,16 +251,7 @@
             },
             {
                 "command": "hubspot.remoteFs.refresh",
-                "title": "Refresh"
-            },
-            {
-                "command": "hubspot.remoteFs.upload",
-                "title": "Upload"
-            },
-            {
-
-                "command": "hubspot.remoteFs.fetch",
-                "title": "Cached Fetch"
+                "title": "Cached Refresh"
             },
             {
                 "command": "hubspot.remoteFs.hardRefresh",
@@ -269,6 +260,14 @@
             {
                 "command": "hubspot.remoteFs.invalidateCache",
                 "title": "Invalidate Cache"
+            },
+            {
+                "command": "hubspot.remoteFs.upload",
+                "title": "Upload"
+            },
+            {
+                "command": "hubspot.remoteFs.fetch",
+                "title": "Fetch"
             },
             {
                 "command": "hubspot.remoteFs.delete",

--- a/package.json
+++ b/package.json
@@ -260,7 +260,15 @@
             {
 
                 "command": "hubspot.remoteFs.fetch",
-                "title": "Fetch"
+                "title": "Cached Fetch"
+            },
+            {
+                "command": "hubspot.remoteFs.hardRefresh",
+                "title": "Refresh"
+            },
+            {
+                "command": "hubspot.remoteFs.invalidateCache",
+                "title": "Invalidate Cache"
             },
             {
                 "command": "hubspot.remoteFs.delete",
@@ -353,7 +361,7 @@
             ],
             "view/title": [
                 {
-                    "command": "hubspot.remoteFs.refresh",
+                    "command": "hubspot.remoteFs.hardRefresh",
                     "when": "view == hubspot.treedata.remoteFs"
                 },
                 {
@@ -412,6 +420,14 @@
                 },
                 {
                     "command": "hubspot.account.viewPersonalAccessKey",
+                    "when": "false"
+                },
+                {
+                    "command": "hubspot.remoteFs.refresh",
+                    "when": "false"
+                },
+                {
+                    "command": "hubspot.remoteFs.invalidateCache",
                     "when": "false"
                 }
             ]

--- a/package.json
+++ b/package.json
@@ -254,6 +254,10 @@
                 "title": "Refresh"
             },
             {
+                "command": "hubspot.remoteFs.upload",
+                "title": "Upload"
+            },
+            {
 
                 "command": "hubspot.remoteFs.fetch",
                 "title": "Fetch"
@@ -289,6 +293,10 @@
                     "command": "hubspot.create.serverlessFunctionFolder",
                     "when": "hubspot.configPath && explorerResourceIsFolder && resource =~ /^(?!.*\\.functions).*$/",
                     "group": "navigation@999"
+                },
+                {
+                    "command": "hubspot.remoteFs.upload",
+                    "when": "hubspot.configPath"
                 }
             ],
             "hubspot.submenus.template": [
@@ -346,6 +354,10 @@
             "view/title": [
                 {
                     "command": "hubspot.remoteFs.refresh",
+                    "when": "view == hubspot.treedata.remoteFs"
+                },
+                {
+                    "command": "hubspot.remoteFs.upload",
                     "when": "view == hubspot.treedata.remoteFs"
                 }
             ],

--- a/src/lib/commands/remoteFs.ts
+++ b/src/lib/commands/remoteFs.ts
@@ -84,14 +84,7 @@ export const registerCommands = (context: ExtensionContext) => {
         }
         deleteFile(getPortalId(), filePath).then(() => {
           window.showInformationMessage(`Successfully deleted ${filePath}`);
-          let parentDirectory = dirname(filePath);
-          if (parentDirectory === '.') {
-            parentDirectory = '/';
-          }
-          commands.executeCommand(
-            'hubspot.remoteFs.invalidateCache',
-            parentDirectory
-          );
+          invalidateParentDirectoryCache(filePath)
           commands.executeCommand('hubspot.remoteFs.refresh');
         });
       }
@@ -154,7 +147,8 @@ export const registerCommands = (context: ExtensionContext) => {
             srcPath,
             destPath
           ).then(async () => {
-            await window.showInformationMessage('Upload succeded');
+            window.showInformationMessage('Upload succeded');
+            invalidateParentDirectoryCache(destPath)
           }).catch(async (error: any) => {
             await window.showErrorMessage(`Upload error: ${error}`);
           })
@@ -172,6 +166,7 @@ export const registerCommands = (context: ExtensionContext) => {
           ).then(async (results: any) => {
             if (!hasUploadErrors(results)) {
               window.showInformationMessage('Upload succeeded');
+              invalidateParentDirectoryCache(destPath)
             } else {
               window.showErrorMessage('Some files failed');
             }
@@ -192,4 +187,15 @@ const getUploadableFileList = async (src: any) => {
     .filter((file: any) => isAllowedExtension(file))
     .filter(createIgnoreFilter());
   return allowedFiles;
+}
+
+const invalidateParentDirectoryCache = (filePath: string) => {
+  let parentDirectory = dirname(filePath);
+  if (parentDirectory === '.') {
+    parentDirectory = '/';
+  }
+  commands.executeCommand(
+    'hubspot.remoteFs.invalidateCache',
+    parentDirectory
+  );
 }

--- a/src/lib/commands/remoteFs.ts
+++ b/src/lib/commands/remoteFs.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs';
+import { existsSync, statSync } from 'fs';
 import { join } from 'path';
 import { ExtensionContext, window, commands, workspace, Uri } from 'vscode';
 import { COMMANDS } from '../constants';
@@ -6,6 +6,13 @@ import { getRootPath } from '../helpers';
 const { deleteFile } = require('@hubspot/cli-lib/api/fileMapper');
 const { downloadFileOrFolder } = require('@hubspot/cli-lib/fileMapper');
 const { getPortalId } = require('@hubspot/cli-lib');
+const { validateSrcAndDestPaths } = require('@hubspot/cli-lib/modules');
+const { shouldIgnoreFile } = require('@hubspot/cli-lib/ignoreRules');
+const { isAllowedExtension } = require('@hubspot/cli-lib/path');
+const { upload } = require('@hubspot/cli-lib/api/fileMapper');
+const { createIgnoreFilter } = require('@hubspot/cli-lib/ignoreRules');
+const { uploadFolder, hasUploadErrors } = require('@hubspot/cli-lib');
+const { walk } = require('@hubspot/cli-lib/lib/walk');
 
 export const registerCommands = (context: ExtensionContext) => {
   context.subscriptions.push(
@@ -75,9 +82,108 @@ export const registerCommands = (context: ExtensionContext) => {
         if (!selection || selection === 'Cancel') {
           return;
         }
-        const res = await deleteFile(getPortalId(), filePath);
-        commands.executeCommand('hubspot.remoteFs.refresh');
+        deleteFile(getPortalId(), filePath).then(() => {
+          console.log(filePath)
+          commands.executeCommand('hubspot.remoteFs.refresh');
+        }).catch(() => {
+          console.log(`Error deleting remote file: ${filePath}`)
+        });
       }
     )
   );
+  context.subscriptions.push(
+    commands.registerCommand(
+      COMMANDS.REMOTE_FS.UPLOAD,
+      async (clickedFileLink) => {
+        let srcPath;
+        if (clickedFileLink === undefined || !(clickedFileLink instanceof Uri)) { // check if Uri, because having a remoteFs tree item selected will show up here too
+          srcPath = await window.showOpenDialog({
+            canSelectFiles: true,
+            canSelectFolders: true,
+            canSelectMany: false,
+            openLabel: 'Upload',
+            title: 'Upload to Remote FS',
+            defaultUri: Uri.from({
+              scheme: 'file',
+              path: getRootPath(),
+            }),
+          });
+          if (srcPath === undefined) {
+            // User didn't select anything
+            return; 
+          }
+          srcPath = srcPath[0].fsPath; // showOpenDialog returns an array of size one
+        } else {
+          srcPath = clickedFileLink.fsPath;
+        }
+        console.log(srcPath);
+        const destPath = await window.showInputBox({
+          prompt: "Remote Destination"
+        })
+        if (destPath === undefined) {
+          return;
+        }
+        console.log(destPath);
+        const srcDestIssues = await validateSrcAndDestPaths(
+          { isLocal: true, path: srcPath },
+          { isHubSpot: true, path: destPath }
+        );
+        if (srcDestIssues.length) {
+          console.log(srcDestIssues)
+          await window.showErrorMessage('Error validating source and destination path during file upload');
+          return;
+        }
+        const stats = statSync(srcPath);
+        if (stats.isFile()) {
+          if (!isAllowedExtension(srcPath)) {
+            await window.showErrorMessage('Disallowed extension');
+            return;
+          }
+          if (shouldIgnoreFile(srcPath)) {
+            await window.showErrorMessage('Ignored file');
+            return;
+          }
+          upload(
+            getPortalId(),
+            srcPath,
+            destPath
+          ).then(async () => {
+            await window.showInformationMessage('Upload succeded');
+          }).catch(async (error: any) => {
+            await window.showErrorMessage(`Upload error: ${error}`);
+          })
+        } else {
+          const filePaths = await getUploadableFileList(srcPath);
+          uploadFolder(
+            getPortalId(),
+            srcPath,
+            destPath,
+            {
+              mode: 'publish'
+            },
+            {},
+            filePaths
+          ).then(async (results: any) => {
+            if (!hasUploadErrors(results)) {
+              window.showInformationMessage('Upload succeeded');
+            } else {
+              window.showErrorMessage('Some files failed');
+            }
+          }).catch(async (error: any) => {
+            window.showErrorMessage('Upload failed');
+          }).finally(() => {
+            commands.executeCommand('hubspot.remoteFs.refresh');
+          })
+        }
+      }
+    )
+  )
 };
+
+const getUploadableFileList = async (src: any) => {
+  const filePaths = await walk(src);
+  const allowedFiles = filePaths
+    .filter((file: any) => isAllowedExtension(file))
+    .filter(createIgnoreFilter());
+  return allowedFiles;
+}

--- a/src/lib/commands/remoteFs.ts
+++ b/src/lib/commands/remoteFs.ts
@@ -1,5 +1,5 @@
 import { existsSync, statSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { ExtensionContext, window, commands, workspace, Uri } from 'vscode';
 import { COMMANDS } from '../constants';
 import { getRootPath } from '../helpers';
@@ -83,10 +83,16 @@ export const registerCommands = (context: ExtensionContext) => {
           return;
         }
         deleteFile(getPortalId(), filePath).then(() => {
-          console.log(filePath)
+          window.showInformationMessage(`Successfully deleted ${filePath}`);
+          let parentDirectory = dirname(filePath);
+          if (parentDirectory === '.') {
+            parentDirectory = '/';
+          }
+          commands.executeCommand(
+            'hubspot.remoteFs.invalidateCache',
+            parentDirectory
+          );
           commands.executeCommand('hubspot.remoteFs.refresh');
-        }).catch(() => {
-          console.log(`Error deleting remote file: ${filePath}`)
         });
       }
     )

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -72,6 +72,7 @@ export const COMMANDS = {
     REFRESH: 'hubspot.remoteFs.refresh',
     FETCH: 'hubspot.remoteFs.fetch',
     DELETE: 'hubspot.remoteFs.delete',
+    UPLOAD: 'hubspot.remoteFs.upload',
   },
   VERSION_CHECK: {
     HS: 'hubspot.versionCheck.hs',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -70,6 +70,8 @@ export const COMMANDS = {
   },
   REMOTE_FS: {
     REFRESH: 'hubspot.remoteFs.refresh',
+    HARD_REFRESH: 'hubspot.remoteFs.hardRefresh',
+    INVALIDATE_CACHE: 'hubspot.remoteFs.invalidateCache',
     FETCH: 'hubspot.remoteFs.fetch',
     DELETE: 'hubspot.remoteFs.delete',
     UPLOAD: 'hubspot.remoteFs.upload',

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -49,6 +49,21 @@ const initializeTreeDataProviders = (context: ExtensionContext) => {
       remoteFsProvider.refresh();
     })
   );
+  context.subscriptions.push(
+    commands.registerCommand(COMMANDS.REMOTE_FS.HARD_REFRESH, () => {
+      console.log(COMMANDS.REMOTE_FS.HARD_REFRESH);
+      remoteFsProvider.hardRefresh();
+    })
+  );
+  context.subscriptions.push(
+    commands.registerCommand(
+      COMMANDS.REMOTE_FS.INVALIDATE_CACHE,
+      (filePath) => {
+        console.log(COMMANDS.REMOTE_FS.INVALIDATE_CACHE);
+        remoteFsProvider.invalidateCache(filePath);
+      }
+    )
+  );
 };
 
 export const initializeProviders = (context: ExtensionContext) => {

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -35,7 +35,7 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
   refresh(): void {
     this._onDidChangeTreeData.fire();
   }
-   
+
   hardRefresh(): void {
     this.remoteFsCache.clear();
     this.refresh();
@@ -52,7 +52,7 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
       }
       return this.invalidateCache(parentDirectory);
     }
-    
+
     // Invalidate the key itself and all child paths
     for (const key of this.remoteFsCache.keys()) {
       if (key.startsWith(filePath)) {

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -8,7 +8,7 @@ import {
   Event,
 } from 'vscode';
 import { FileLink, RemoteFsDirectory } from '../types';
-
+import { dirname } from 'path';
 const {
   getDirectoryContentsByPath,
 } = require('@hubspot/cli-lib/api/fileMapper');
@@ -43,6 +43,16 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
 
   invalidateCache(filePath: string): void {
     console.log(`Invalidating cache for ${filePath}`);
+    /* If it's not in the cache, invalidate the parent directory
+       This helps for uploading when the destination folder doesn't exist yet */
+    if (this.remoteFsCache.get(filePath) === undefined && filePath !== '/') {
+      let parentDirectory = dirname(filePath);
+      if (parentDirectory === '.') {
+        parentDirectory = '/';
+      }
+      return this.invalidateCache(parentDirectory);
+    }
+    
     // Invalidate the key itself and all child paths
     for (const key of this.remoteFsCache.keys()) {
       if (key.startsWith(filePath)) {

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -30,10 +30,23 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
   > = new EventEmitter<FileLink | undefined | null | void>();
   readonly onDidChangeTreeData: Event<void | FileLink | null | undefined> =
     this._onDidChangeTreeData.event;
+  private remoteFsCache: Map<string, RemoteFsDirectory> = new Map();
 
   refresh(): void {
     this._onDidChangeTreeData.fire();
   }
+   
+  hardRefresh(): void {
+    this.remoteFsCache.clear();
+    this.refresh();
+  }
+
+  invalidateCache(filePath: string): void {
+    console.log(`Invalidating cache for ${filePath}`);
+    this.remoteFsCache.delete(filePath);
+    this.refresh();
+  }
+
   getTreeItem(fileLink: FileLink): TreeItem {
     return fileLink.url
       ? new RemoteFsTreeItem(
@@ -51,9 +64,16 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
 
   async getChildren(parent?: FileLink): Promise<FileLink[]> {
     const remoteDirectory: string = parent?.path ? parent.path : '/';
-    const directoryContents: RemoteFsDirectory =
-      await getDirectoryContentsByPath(getPortalId(), remoteDirectory);
-    const fileOrFolderList = directoryContents.children.map((f) => {
+
+    let directoryContents: any = this.remoteFsCache.get(remoteDirectory);
+    if (directoryContents === undefined) {
+      directoryContents = await getDirectoryContentsByPath(
+        getPortalId(),
+        remoteDirectory
+      );
+      this.remoteFsCache.set(remoteDirectory, directoryContents);
+    }
+    const fileOrFolderList = directoryContents.children.map((f: string) => {
       return isPathFolder(f)
         ? {
             label: f,

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -43,7 +43,12 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
 
   invalidateCache(filePath: string): void {
     console.log(`Invalidating cache for ${filePath}`);
-    this.remoteFsCache.delete(filePath);
+    // Invalidate the key itself and all child paths
+    for (const key of this.remoteFsCache.keys()) {
+      if (key.startsWith(filePath)) {
+        this.remoteFsCache.delete(key);
+      }
+    }
     this.refresh();
   }
 


### PR DESCRIPTION
Depends on https://github.com/HubSpot/hubspot-cms-vscode/pull/213/files (changes from that PR are included here)

Adds remote fs upload functionality. Doesn't include support for fieldsjs, I wanted to make this as simple as possible for now and I'm not sure that feature is fully supported yet / gets a ton of use, if we want to add it down the line there's certainly room for it but this is a pretty big chunk as-is.