### PR TITLE
Remote FS Watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -262,8 +262,20 @@
                 "title": "Invalidate Cache"
             },
             {
+                "command": "hubspot.remoteFs.startWatch",
+                "title": "Start Watch"
+            },
+            {
+                "command": "hubspot.remoteFs.endWatch",
+                "title": "End Watch"
+            },
+            {
                 "command": "hubspot.remoteFs.upload",
                 "title": "Upload"
+            },
+            {
+                "command": "hubspot.remoteFs.watch",
+                "title": "Watch"
             },
             {
                 "command": "hubspot.remoteFs.fetch",
@@ -304,6 +316,10 @@
                 {
                     "command": "hubspot.remoteFs.upload",
                     "when": "hubspot.configPath"
+                },
+                {
+                    "command": "hubspot.remoteFs.watch",
+                    "when": "hubspot.configPath && explorerResourceIsFolder"
                 }
             ],
             "hubspot.submenus.template": [
@@ -356,6 +372,10 @@
                 {
                     "command": "hubspot.remoteFs.delete",
                     "when": "viewItem == remoteFsTreeItem"
+                },
+                {
+                    "command": "hubspot.remoteFs.endWatch",
+                    "when": "viewItem == syncedRemoteFsTreeItem"
                 }
             ],
             "view/title": [
@@ -365,6 +385,10 @@
                 },
                 {
                     "command": "hubspot.remoteFs.upload",
+                    "when": "view == hubspot.treedata.remoteFs"
+                },
+                {
+                    "command": "hubspot.remoteFs.watch",
                     "when": "view == hubspot.treedata.remoteFs"
                 }
             ],
@@ -427,6 +451,10 @@
                 },
                 {
                     "command": "hubspot.remoteFs.invalidateCache",
+                    "when": "false"
+                },
+                {
+                    "command": "hubspot.remoteFs.startWatch",
                     "when": "false"
                 }
             ]

--- a/src/lib/commands/remoteFs.ts
+++ b/src/lib/commands/remoteFs.ts
@@ -3,6 +3,7 @@ import { join, dirname } from 'path';
 import { ExtensionContext, window, commands, workspace, Uri } from 'vscode';
 import { COMMANDS } from '../constants';
 import { getRootPath } from '../helpers';
+import { invalidateParentDirectoryCache } from '../helpers';
 
 const { deleteFile } = require('@hubspot/cli-lib/api/fileMapper');
 const { downloadFileOrFolder } = require('@hubspot/cli-lib/fileMapper');
@@ -199,14 +200,6 @@ const getUploadableFileList = async (src: any) => {
     .filter((file: any) => isAllowedExtension(file))
     .filter(createIgnoreFilter());
   return allowedFiles;
-};
-
-const invalidateParentDirectoryCache = (filePath: string) => {
-  let parentDirectory = dirname(filePath);
-  if (parentDirectory === '.') {
-    parentDirectory = '/';
-  }
-  commands.executeCommand('hubspot.remoteFs.invalidateCache', parentDirectory);
 };
 
 const handleFileUpload = async (srcPath: string, destPath: string) => {

--- a/src/lib/commands/remoteFs.ts
+++ b/src/lib/commands/remoteFs.ts
@@ -180,8 +180,13 @@ export const registerCommands = (context: ExtensionContext) => {
         if (destPath === undefined || destPath.length === 0) {
           return;
         }
-        const filesToUpload = await getUploadableFileList(srcPath); 
-        commands.executeCommand(COMMANDS.REMOTE_FS.START_WATCH, srcPath, destPath, filesToUpload)
+        const filesToUpload = await getUploadableFileList(srcPath);
+        commands.executeCommand(
+          COMMANDS.REMOTE_FS.START_WATCH,
+          srcPath,
+          destPath,
+          filesToUpload
+        );
         invalidateParentDirectoryCache(destPath);
       }
     )

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -77,7 +77,7 @@ export const COMMANDS = {
     UPLOAD: 'hubspot.remoteFs.upload',
     WATCH: 'hubspot.remoteFs.watch',
     START_WATCH: 'hubspot.remoteFs.startWatch',
-    END_WATCH: 'hubspot.remoteFs.endWatch'
+    END_WATCH: 'hubspot.remoteFs.endWatch',
   },
   VERSION_CHECK: {
     HS: 'hubspot.versionCheck.hs',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -75,6 +75,9 @@ export const COMMANDS = {
     FETCH: 'hubspot.remoteFs.fetch',
     DELETE: 'hubspot.remoteFs.delete',
     UPLOAD: 'hubspot.remoteFs.upload',
+    WATCH: 'hubspot.remoteFs.watch',
+    START_WATCH: 'hubspot.remoteFs.startWatch',
+    END_WATCH: 'hubspot.remoteFs.endWatch'
   },
   VERSION_CHECK: {
     HS: 'hubspot.versionCheck.hs',

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,4 +1,6 @@
-import { workspace } from 'vscode';
+import { dirname } from 'path';
+import { commands, workspace } from 'vscode';
+import { COMMANDS } from './constants';
 import { HubspotConfig, Portal } from './types';
 
 const { exec } = require('node:child_process');
@@ -82,4 +84,12 @@ export const checkTerminalCommandVersion = async (
       resolve(undefined);
     }
   });
+};
+
+export const invalidateParentDirectoryCache = (filePath: string) => {
+  let parentDirectory = dirname(filePath);
+  if (parentDirectory === '.') {
+    parentDirectory = '/';
+  }
+  commands.executeCommand(COMMANDS.REMOTE_FS.INVALIDATE_CACHE, parentDirectory);
 };

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -64,6 +64,24 @@ const initializeTreeDataProviders = (context: ExtensionContext) => {
       }
     )
   );
+  context.subscriptions.push(
+    commands.registerCommand(
+      COMMANDS.REMOTE_FS.START_WATCH,
+      (srcPath, destPath, filesToUpload) => {
+        console.log(COMMANDS.REMOTE_FS.START_WATCH);
+        remoteFsProvider.changeWatch(srcPath, destPath, filesToUpload);
+      }
+    )
+  );
+  context.subscriptions.push(
+    commands.registerCommand(
+      COMMANDS.REMOTE_FS.END_WATCH,
+      () => {
+        console.log(COMMANDS.REMOTE_FS.END_WATCH);
+        remoteFsProvider.endWatch();
+      }
+    )
+  )
 };
 
 export const initializeProviders = (context: ExtensionContext) => {

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -74,14 +74,11 @@ const initializeTreeDataProviders = (context: ExtensionContext) => {
     )
   );
   context.subscriptions.push(
-    commands.registerCommand(
-      COMMANDS.REMOTE_FS.END_WATCH,
-      () => {
-        console.log(COMMANDS.REMOTE_FS.END_WATCH);
-        remoteFsProvider.endWatch();
-      }
-    )
-  )
+    commands.registerCommand(COMMANDS.REMOTE_FS.END_WATCH, () => {
+      console.log(COMMANDS.REMOTE_FS.END_WATCH);
+      remoteFsProvider.endWatch();
+    })
+  );
 };
 
 export const initializeProviders = (context: ExtensionContext) => {

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -113,6 +113,7 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
       console.log(
         `Set new watcher from ${this.watchedSrc} => ${this.watchedDest}`
       );
+      this.invalidateCache(this.watchedDest);
     };
     if (this.currentWatcher) {
       this.currentWatcher.close().then(() => {

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -72,11 +72,10 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
     if (this.currentWatcher) {
       this.currentWatcher.close().then(() => {
         console.log(`Closed existing watcher on ${this.watchedDest}`);
+        this.watchedSrc = '';
+        this.watchedDest = '';
+        this.currentWatcher = null;
       });
-      this.invalidateCache(this.watchedDest);
-      this.watchedSrc = '';
-      this.watchedDest = '';
-      this.currentWatcher = null;
     }
   }
 

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -81,10 +81,12 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
   }
 
   /* If watching /Example/directory -> example/remotefs
-  *  then /Example/directory/hello.html returns example/remotefs/hello.html
-  */
+   *  then /Example/directory/hello.html returns example/remotefs/hello.html
+   */
   equivalentRemotePath(localPath: string) {
-    const posixWatchedSrc = this.watchedSrc.split(path.sep).join(path.posix.sep);
+    const posixWatchedSrc = this.watchedSrc
+      .split(path.sep)
+      .join(path.posix.sep);
     const posixLocalPath = localPath.split(path.sep).join(path.posix.sep);
     const posixRelativePath = path.relative(posixWatchedSrc, posixLocalPath);
     return path.join(this.watchedDest, posixRelativePath);

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -33,7 +33,7 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
     this._onDidChangeTreeData.event;
   private remoteFsCache: Map<string, RemoteFsDirectory> = new Map();
   private watchedPath: string = '';
-  private currentWatcher: any = null; 
+  private currentWatcher: any = null;
 
   refresh(): void {
     this._onDidChangeTreeData.fire();
@@ -79,25 +79,20 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
 
   changeWatch(srcPath: string, destPath: string, filesToUpload: any): void {
     const setWatch = () => {
-      this.currentWatcher = watch(
-        getPortalId(),
-        srcPath,
-        destPath,
-        {
-          mode: 'publish',
-          remove: true,
-          disableInitial: false,
-          notify: false,
-          commandOptions: {},
-          filePaths: filesToUpload
-        }
-      );
+      this.currentWatcher = watch(getPortalId(), srcPath, destPath, {
+        mode: 'publish',
+        remove: true,
+        disableInitial: false,
+        notify: false,
+        commandOptions: {},
+        filePaths: filesToUpload,
+      });
       this.currentWatcher.on('raw', (event: any, path: any, details: any) => {
-        this.invalidateCache(destPath)
+        this.invalidateCache(destPath);
       });
       this.watchedPath = destPath;
       console.log(`Set new watcher on ${this.watchedPath}`);
-    }
+    };
     if (this.currentWatcher) {
       this.currentWatcher.close().then(() => {
         console.log(`Closed existing watcher on ${this.watchedPath}`);
@@ -134,22 +129,26 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
       );
       this.remoteFsCache.set(remoteDirectory, directoryContents);
     }
-    const fileOrFolderList = directoryContents.children.map((filePath: string) => {
-      if (isPathFolder(filePath)) {
-        const path = parent ? `${parent.path}/${filePath}` : filePath;
-        return {
-          label: filePath,
-          path: path,
-          icon: path === this.watchedPath ? 'sync' : 'symbol-folder'
-        };
-      } else {
-        return {
-          label: filePath,
-          url: parent ? `hubl:${parent.path}/${filePath}` : `hubl:${filePath}`,
-          icon: 'file-code'
-        };
+    const fileOrFolderList = directoryContents.children.map(
+      (filePath: string) => {
+        if (isPathFolder(filePath)) {
+          const path = parent ? `${parent.path}/${filePath}` : filePath;
+          return {
+            label: filePath,
+            path: path,
+            icon: path === this.watchedPath ? 'sync' : 'symbol-folder',
+          };
+        } else {
+          return {
+            label: filePath,
+            url: parent
+              ? `hubl:${parent.path}/${filePath}`
+              : `hubl:${filePath}`,
+            icon: 'file-code',
+          };
+        }
       }
-    });
+    );
     return Promise.resolve(fileOrFolderList);
   }
 }


### PR DESCRIPTION
Adds watch functionality to VSCE. Similar to upload, watch can be initiated either via right-click on the desired folder in the explorer, or via the dropdown context in the remote FS view. The user will then be prompted for the remote path with which to sync.

The synced folder is then given a special icon in the remote FS view, and the watch session can be cancelled with a right click action, or by initiating another session. Only one watch session can be active at a time.

![Screenshot 2023-03-28 at 5 02 17 PM](https://user-images.githubusercontent.com/25852903/228366062-6a75dc25-3b24-4558-8397-c85e5edcdf21.png)

Changes to the local filesystem are watched using `chokidar` in `cli-lib`, and a special event is added for VSCE to invalidate the remote FS cache when files are removed, added, or moved. 