### PR TITLE
Improve UX feedback during large uploads

### DIFF
--- a/src/lib/commands/remoteFs.ts
+++ b/src/lib/commands/remoteFs.ts
@@ -1,8 +1,15 @@
 import { existsSync, statSync } from 'fs';
 import { join, dirname } from 'path';
-import { ExtensionContext, window, commands, workspace, Uri } from 'vscode';
+import {
+  ExtensionContext,
+  window,
+  commands,
+  workspace,
+  Uri,
+  StatusBarAlignment,
+} from 'vscode';
 import { COMMANDS } from '../constants';
-import { getRootPath } from '../helpers';
+import { buildUploadingStatusBarItem, getRootPath } from '../helpers';
 import { invalidateParentDirectoryCache } from '../helpers';
 
 const { deleteFile } = require('@hubspot/cli-lib/api/fileMapper');
@@ -231,6 +238,9 @@ const handleFileUpload = async (srcPath: string, destPath: string) => {
 
 const handleFolderUpload = async (srcPath: string, destPath: string) => {
   const filePaths = await getUploadableFileList(srcPath);
+  const uploadingStatus = buildUploadingStatusBarItem();
+  uploadingStatus.show();
+  window.showInformationMessage('Beginning upload...');
   uploadFolder(
     getPortalId(),
     srcPath,
@@ -262,6 +272,7 @@ const handleFolderUpload = async (srcPath: string, destPath: string) => {
       );
     })
     .finally(() => {
+      uploadingStatus.dispose();
       commands.executeCommand('hubspot.remoteFs.refresh');
     });
 };

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,5 +1,5 @@
 import { dirname } from 'path';
-import { commands, workspace } from 'vscode';
+import { window, commands, workspace, StatusBarAlignment } from 'vscode';
 import { COMMANDS } from './constants';
 import { HubspotConfig, Portal } from './types';
 
@@ -92,4 +92,10 @@ export const invalidateParentDirectoryCache = (filePath: string) => {
     parentDirectory = '/';
   }
   commands.executeCommand(COMMANDS.REMOTE_FS.INVALIDATE_CACHE, parentDirectory);
+};
+
+export const buildUploadingStatusBarItem = () => {
+  const statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right);
+  statusBarItem.text = 'Uploading...';
+  return statusBarItem;
 };


### PR DESCRIPTION
Fixes an issue where during a large upload no UX feedback occurred, leading to confusion for users. Now when uploading a folder via Upload, or the initial upload via Watch

- A `window.showInformationMessage` is displayed to bring attention to the upload initialization

- A status bar item is added until the upload process finishes

- A final `window.showInformationMessage` displays once the upload is finished.

This change requires a minor change to `cli-lib` to add an optional callback to `watch` to run after the initial upload completes. Here we use said callback to display upload messaging as well as invalidate the cache and refresh the display.