### PR TITLE
Clean up commands to consts, add tracking, refresh remotefs on default account change

### DIFF
--- a/src/lib/commands/config.ts
+++ b/src/lib/commands/config.ts
@@ -58,7 +58,7 @@ export const registerCommands = (context: ExtensionContext) => {
         console.log('Setting default account to: ', newDefaultAccount);
         updateDefaultAccount(newDefaultAccount);
         await trackEvent(TRACKED_EVENTS.UPDATE_DEFAULT_ACCOUNT);
-        commands.executeCommand('hubspot.remoteFs.refresh');
+        commands.executeCommand(COMMANDS.REMOTE_FS.HARD_REFRESH);
         if (!silenceNotification) {
           showAutoDismissedStatusBarMessage(
             `Successfully set default account to ${newDefaultAccount}.`
@@ -101,6 +101,7 @@ export const registerCommands = (context: ExtensionContext) => {
                 showAutoDismissedStatusBarMessage(
                   `Successfully set default account to ${newDefaultAccount}.`
                 );
+                commands.executeCommand(COMMANDS.REMOTE_FS.HARD_REFRESH);
               }
             });
         }
@@ -145,7 +146,7 @@ export const registerCommands = (context: ExtensionContext) => {
                 );
               }
               await trackEvent(TRACKED_EVENTS.DELETE_ACCOUNT);
-              commands.executeCommand('hubspot.remoteFs.refresh');
+              commands.executeCommand(COMMANDS.REMOTE_FS.HARD_REFRESH);
               updateStatusBarItems();
             }
           });

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -127,6 +127,13 @@ export const TRACKED_EVENTS = {
   },
   LINTING_ENABLED: 'lintingEnabled',
   LINTING_DISABLED: 'lintingDisabled',
+  REMOTE_FS: {
+    WATCH: 'remoteFsWatch',
+    UPLOAD_FILE: 'remoteFsUploadFile',
+    UPLOAD_FOLDER: 'remoteFsUploadFolder',
+    DELETE: 'remoteFsDelete',
+    FETCH: 'remoteFsFetch',
+  },
   RENAME_ACCOUNT: 'accountRenamed',
   RENAME_ACCOUNT_ERROR: 'accountRenameError',
   SELECT_DEFAULT_ACCOUNT: 'selectedDefaultAccount',

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -14,6 +14,8 @@ import {
   buildUploadingStatusBarItem,
   invalidateParentDirectoryCache,
 } from '../helpers';
+import { trackEvent } from '../tracking';
+import { TRACKED_EVENTS } from '../constants';
 const {
   getDirectoryContentsByPath,
 } = require('@hubspot/cli-lib/api/fileMapper');
@@ -97,6 +99,7 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
   }
 
   changeWatch(srcPath: string, destPath: string, filesToUpload: any): void {
+    trackEvent(TRACKED_EVENTS.REMOTE_FS.WATCH);
     const setWatch = () => {
       const uploadingStatus = buildUploadingStatusBarItem();
       uploadingStatus.show();


### PR DESCRIPTION
See title! Some of these `hubspot.remoteFs.refresh`s should be hard refreshes, they were just put in before there was a cache so there was no distinction, went ahead and switched them over. Also removed some unused imports and added tracking for basic remoteFs events.