### PR TITLE
Add @hubspot folder to remote FS view

### DIFF
--- a/package.json
+++ b/package.json
@@ -376,7 +376,7 @@
                 },
                 {
                     "command": "hubspot.remoteFs.fetch",
-                    "when": "viewItem == remoteFsTreeItem"
+                    "when": "viewItem == remoteFsTreeItem || viewItem == defaultRemoteFsTreeItem"
                 },
                 {
                     "command": "hubspot.remoteFs.delete",

--- a/src/lib/commands/remoteFs.ts
+++ b/src/lib/commands/remoteFs.ts
@@ -22,10 +22,7 @@ export const registerCommands = (context: ExtensionContext) => {
     commands.registerCommand(
       COMMANDS.REMOTE_FS.FETCH,
       async (clickedFileLink) => {
-        const fileLinkIsFolder = clickedFileLink.icon === 'symbol-folder';
-        const remoteFilePath = fileLinkIsFolder
-          ? clickedFileLink.path
-          : clickedFileLink.url.slice(5);
+        const remoteFilePath = clickedFileLink.path;
         // We use showOpenDialog instead of showSaveDialog because the latter has worse support for this use-case
         const destPath = await window.showOpenDialog({
           canSelectFiles: false,
@@ -80,10 +77,7 @@ export const registerCommands = (context: ExtensionContext) => {
       COMMANDS.REMOTE_FS.DELETE,
       async (clickedFileLink) => {
         console.log(COMMANDS.REMOTE_FS.DELETE);
-        const fileLinkIsFolder = clickedFileLink.icon === 'symbol-folder';
-        const filePath = fileLinkIsFolder
-          ? clickedFileLink.path
-          : clickedFileLink.url.slice(5);
+        const filePath = clickedFileLink.path;
         const selection = await window.showWarningMessage(
           `Are you sure you want to delete ${filePath}? This action cannot be undone.`,
           ...['Okay', 'Cancel']

--- a/src/lib/providers/remoteFileProvider.ts
+++ b/src/lib/providers/remoteFileProvider.ts
@@ -12,10 +12,7 @@ export const RemoteFileProvider = new (class
     const filepath = uri.toString().split(':')[1];
     try {
       // filepath must be de-encoded since it gets reencoded by download in cli-lib
-      const file = await download(
-        getPortalId(),
-        decodeURIComponent(filepath)
-      );
+      const file = await download(getPortalId(), decodeURIComponent(filepath));
       return file.source;
     } catch (e) {
       console.log(e);

--- a/src/lib/providers/remoteFileProvider.ts
+++ b/src/lib/providers/remoteFileProvider.ts
@@ -14,7 +14,7 @@ export const RemoteFileProvider = new (class
       // filepath must be de-encoded since it gets reencoded by download in cli-lib
       const file = await download(
         getPortalId(),
-        `/${decodeURIComponent(filepath)}`
+        decodeURIComponent(filepath)
       );
       return file.source;
     } catch (e) {

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -167,6 +167,11 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
       // Default content wasn't originally in this endpoint and so doesn't show up unless manually queried
       if (remoteDirectory === '/') {
         directoryContents.children = ['@hubspot', ...directoryContents.children];
+      } else if (remoteDirectory === '@hubspot') {
+        // Small QoL to move themes to top and modules to bottom of the display like DMUI does
+        const noModules = directoryContents.children.filter((f: string) => !f.endsWith('.module'));
+        const onlyModules = directoryContents.children.filter((f: string) => f.endsWith('.module'));
+        directoryContents.children = [...noModules, ...onlyModules];
       }
       this.remoteFsCache.set(remoteDirectory, directoryContents);
     }

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -172,12 +172,12 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
         ];
       } else if (remoteDirectory === '@hubspot') {
         // Small QoL to move themes to top and modules to bottom of the display like DMUI does
-        const noModules = directoryContents.children.filter(
-          (f: string) => !f.endsWith('.module')
-        );
-        const onlyModules = directoryContents.children.filter((f: string) =>
-          f.endsWith('.module')
-        );
+        const noModules = directoryContents.children
+          .filter((f: string) => !f.endsWith('.module'))
+          .sort();
+        const onlyModules = directoryContents.children
+          .filter((f: string) => f.endsWith('.module'))
+          .sort();
         directoryContents.children = [...noModules, ...onlyModules];
       }
       this.remoteFsCache.set(remoteDirectory, directoryContents);

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -166,17 +166,26 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
       );
       // Default content wasn't originally in this endpoint and so doesn't show up unless manually queried
       if (remoteDirectory === '/') {
-        directoryContents.children = ['@hubspot', ...directoryContents.children];
+        directoryContents.children = [
+          '@hubspot',
+          ...directoryContents.children,
+        ];
       } else if (remoteDirectory === '@hubspot') {
         // Small QoL to move themes to top and modules to bottom of the display like DMUI does
-        const noModules = directoryContents.children.filter((f: string) => !f.endsWith('.module'));
-        const onlyModules = directoryContents.children.filter((f: string) => f.endsWith('.module'));
+        const noModules = directoryContents.children.filter(
+          (f: string) => !f.endsWith('.module')
+        );
+        const onlyModules = directoryContents.children.filter((f: string) =>
+          f.endsWith('.module')
+        );
         directoryContents.children = [...noModules, ...onlyModules];
       }
       this.remoteFsCache.set(remoteDirectory, directoryContents);
     }
     const buildFileLinkFromPath = this.curriedFileLinkFromPathBuilder(parent);
-    const fileOrFolderList = directoryContents.children.map(buildFileLinkFromPath);
+    const fileOrFolderList = directoryContents.children.map(
+      buildFileLinkFromPath
+    );
     return Promise.resolve(fileOrFolderList);
   }
 
@@ -189,18 +198,18 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
         isDefault: filePath.startsWith('@hubspot'),
         isFolder: isPathFolder(fileName),
         isSynced: this.watchedDest === filePath,
-      }
-    }
+      };
+    };
   }
 }
 
 export class RemoteFsTreeItem extends TreeItem {
-  constructor(
-    public readonly fileLink: FileLink
-  ) {
+  constructor(public readonly fileLink: FileLink) {
     const getCollapsibleState = (fileLink: FileLink) => {
-      return fileLink.isFolder ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None;
-    }
+      return fileLink.isFolder
+        ? TreeItemCollapsibleState.Collapsed
+        : TreeItemCollapsibleState.None;
+    };
     super(fileLink.label, getCollapsibleState(fileLink));
     this.contextValue = this.getContextValue(fileLink);
     if (!fileLink.isFolder) {
@@ -215,16 +224,16 @@ export class RemoteFsTreeItem extends TreeItem {
     this.iconPath = new ThemeIcon(this.getIcon(fileLink));
   }
 
-  getContextValue (fileLink: FileLink) {
+  getContextValue(fileLink: FileLink) {
     if (fileLink.isDefault) {
       return 'defaultRemoteFsTreeItem';
     } else if (fileLink.isSynced) {
       return 'syncedRemoteFsTreeItem';
     } else {
-      return 'remoteFsTreeItem'
+      return 'remoteFsTreeItem';
     }
   }
-  getIcon (fileLink: FileLink) {
+  getIcon(fileLink: FileLink) {
     if (fileLink.label === '@hubspot') {
       return 'lock';
     } else if (fileLink.isSynced) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,9 +56,10 @@ export interface HubLValidationError {
 
 export interface FileLink {
   label: string;
-  url?: string;
-  path?: string;
-  icon: string;
+  path: string;
+  isDefault: boolean;
+  isFolder: boolean;
+  isSynced: boolean;
 }
 
 export interface RemoteFsDirectory {


### PR DESCRIPTION
Adds @hubspot folder to the remote FS view. Always appears at the top of the root directory with a locked icon. Contents are split between themes and modules and sorted, the same way they appear in the Design Manager.

![Screenshot 2023-04-14 at 3 46 51 PM](https://user-images.githubusercontent.com/25852903/232141346-f9b9896b-955e-4391-9aeb-585919834a5e.png)

Also did some refactoring of the tree building code to hopefully make it a little easier to read. FileLinks are now just the logical aspect of the file / path and its properties, and all decorative / presentation stuff is in the RemoteFsTreeItem constructor. Feels much nicer that way! 