### PR TITLE
Logger override, add error catch for delete 

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { registerCommands } from './lib/commands';
 import { registerEvents } from './lib/events';
 import { registerURIHandler } from './lib/uri';
 
+import { initializeCliLibLogger } from './lib/logger';
 import { initializeStatusBar } from './lib/statusBar';
 import { initializeProviders } from './lib/providers';
 import { initializeConfig } from './lib/auth';
@@ -16,6 +17,7 @@ import { initializeTracking, trackEvent } from './lib/tracking';
 import { initializeGlobalState } from './lib/globalState';
 
 export const activate = async (context: ExtensionContext) => {
+  initializeCliLibLogger();
   initializeTracking(context);
   await trackEvent(TRACKED_EVENTS.ACTIVATE);
   console.log(

--- a/src/lib/commands/remoteFs.ts
+++ b/src/lib/commands/remoteFs.ts
@@ -92,15 +92,22 @@ export const registerCommands = (context: ExtensionContext) => {
         trackEvent(TRACKED_EVENTS.REMOTE_FS.DELETE);
         const deletingStatus = buildStatusBarItem(`Deleting...`);
         deletingStatus.show();
-        deleteFile(getPortalId(), filePath).then(() => {
-          window.showInformationMessage(`Successfully deleted "${filePath}"`);
-          invalidateParentDirectoryCache(filePath);
-          commands.executeCommand(COMMANDS.REMOTE_FS.REFRESH);
-        }).catch((err: any) => {
-          window.showErrorMessage(`Error deleting "${filePath}": ${JSON.parse(err.message.slice(5)).message}`)
-        }).finally(() => {
-          deletingStatus.dispose();
-        });
+        deleteFile(getPortalId(), filePath)
+          .then(() => {
+            window.showInformationMessage(`Successfully deleted "${filePath}"`);
+            invalidateParentDirectoryCache(filePath);
+            commands.executeCommand(COMMANDS.REMOTE_FS.REFRESH);
+          })
+          .catch((err: any) => {
+            window.showErrorMessage(
+              `Error deleting "${filePath}": ${
+                JSON.parse(err.message.slice(5)).message
+              }`
+            );
+          })
+          .finally(() => {
+            deletingStatus.dispose();
+          });
       }
     )
   );

--- a/src/lib/commands/remoteFs.ts
+++ b/src/lib/commands/remoteFs.ts
@@ -95,8 +95,11 @@ export const registerCommands = (context: ExtensionContext) => {
         deleteFile(getPortalId(), filePath).then(() => {
           window.showInformationMessage(`Successfully deleted "${filePath}"`);
           invalidateParentDirectoryCache(filePath);
-          deletingStatus.dispose();
           commands.executeCommand(COMMANDS.REMOTE_FS.REFRESH);
+        }).catch((err: any) => {
+          window.showErrorMessage(`Error deleting "${filePath}": ${JSON.parse(err.message.slice(5)).message}`)
+        }).finally(() => {
+          deletingStatus.dispose();
         });
       }
     )

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,34 +1,34 @@
-import { window } from "vscode";
+import { window } from 'vscode';
 
 const { setLogger } = require('@hubspot/cli-lib/logger');
 
 class Logger {
-    error(...args: any[]) {
-        window.showErrorMessage(`[CLI-error]: ${args}`);
-    }
-    warn(...args:any[]){
-        window.showWarningMessage(`[CLI-warning] ${args}`);
-    }
-    log(...args:any[]){
-        window.showInformationMessage(`[CLI-log] ${args}`);
-    }
-    success(...args: any[]) {
-        window.showInformationMessage(`[CLI-success] ${args}`);
-    }
-    info(...args: any[]) {
-        window.showInformationMessage(`[CLI-info] ${args}`);
-    }
-    debug(...args: any[]) {
-        window.showWarningMessage(`[CLI-debug]: ${args}`);
-    }
-    group(...args: any[]) {
-        console.group(...args)
-    }
-    groupEnd(...args: any[]) {
-        console.groupEnd()
-    }
+  error(...args: any[]) {
+    window.showErrorMessage(`[error]: ${args}`);
+  }
+  warn(...args: any[]) {
+    window.showWarningMessage(`[warning] ${args}`);
+  }
+  log(...args: any[]) {
+    window.showInformationMessage(`[log] ${args}`);
+  }
+  success(...args: any[]) {
+    window.showInformationMessage(`[success] ${args}`);
+  }
+  info(...args: any[]) {
+    window.showInformationMessage(`[info] ${args}`);
+  }
+  debug(...args: any[]) {
+    window.showWarningMessage(`[debug]: ${args}`);
+  }
+  group(...args: any[]) {
+    console.group(...args);
+  }
+  groupEnd(...args: any[]) {
+    console.groupEnd();
+  }
 }
 export const initializeCliLibLogger = () => {
-    const vsceLogger = new Logger();
-    setLogger(vsceLogger);
-}
+  const vsceLogger = new Logger();
+  setLogger(vsceLogger);
+};

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,34 @@
+import { window } from "vscode";
+
+const { setLogger } = require('@hubspot/cli-lib/logger');
+
+class Logger {
+    error(...args: any[]) {
+        window.showErrorMessage(`[CLI-error]: ${args}`);
+    }
+    warn(...args:any[]){
+        window.showWarningMessage(`[CLI-warning] ${args}`);
+    }
+    log(...args:any[]){
+        window.showInformationMessage(`[CLI-log] ${args}`);
+    }
+    success(...args: any[]) {
+        window.showInformationMessage(`[CLI-success] ${args}`);
+    }
+    info(...args: any[]) {
+        window.showInformationMessage(`[CLI-info] ${args}`);
+    }
+    debug(...args: any[]) {
+        window.showWarningMessage(`[CLI-debug]: ${args}`);
+    }
+    group(...args: any[]) {
+        console.group(...args)
+    }
+    groupEnd(...args: any[]) {
+        console.groupEnd()
+    }
+}
+export const initializeCliLibLogger = () => {
+    const vsceLogger = new Logger();
+    setLogger(vsceLogger);
+}


### PR DESCRIPTION
Now overrides the [cli-lib logger ](https://github.com/HubSpot/hubspot-cli/blob/8aafada9270602e912d89fc6a513816f5f7232bb/packages/cli-lib/logger.js#L32) to instead surface the error messages within the VSCode window. Also adds a catch/finally to delete function to not break if an error occurs.