### PR TITLE
Sort remote directory alphabetically

### DIFF
--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -182,7 +182,7 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
           .sort();
         directoryContents.children = [...noModules, ...onlyModules];
       } else {
-        directoryContents.children.sort()
+        directoryContents.children.sort();
       }
       this.remoteFsCache.set(remoteDirectory, directoryContents);
     }
@@ -202,7 +202,7 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
         isDefault: filePath.startsWith('@hubspot'),
         isFolder: isPathFolder(fileName),
         isSynced: this.watchedDest === filePath,
-      })
+      });
       return {
         label: fileName,
         path: filePath,

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -196,13 +196,6 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
   curriedFileLinkFromPathBuilder(parent?: FileLink) {
     return (fileName: string): FileLink => {
       const filePath = parent ? `${parent.path}/${fileName}` : fileName;
-      console.log({
-        label: fileName,
-        path: filePath,
-        isDefault: filePath.startsWith('@hubspot'),
-        isFolder: isPathFolder(fileName),
-        isSynced: this.watchedDest === filePath,
-      });
       return {
         label: fileName,
         path: filePath,

--- a/src/lib/providers/remoteFsProvider.ts
+++ b/src/lib/providers/remoteFsProvider.ts
@@ -170,7 +170,7 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
       if (remoteDirectory === '/') {
         directoryContents.children = [
           '@hubspot',
-          ...directoryContents.children,
+          ...directoryContents.children.sort(),
         ];
       } else if (remoteDirectory === '@hubspot') {
         // Small QoL to move themes to top and modules to bottom of the display like DMUI does
@@ -181,6 +181,8 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
           .filter((f: string) => f.endsWith('.module'))
           .sort();
         directoryContents.children = [...noModules, ...onlyModules];
+      } else {
+        directoryContents.children.sort()
       }
       this.remoteFsCache.set(remoteDirectory, directoryContents);
     }
@@ -194,6 +196,13 @@ export class RemoteFsProvider implements TreeDataProvider<FileLink> {
   curriedFileLinkFromPathBuilder(parent?: FileLink) {
     return (fileName: string): FileLink => {
       const filePath = parent ? `${parent.path}/${fileName}` : fileName;
+      console.log({
+        label: fileName,
+        path: filePath,
+        isDefault: filePath.startsWith('@hubspot'),
+        isFolder: isPathFolder(fileName),
+        isSynced: this.watchedDest === filePath,
+      })
       return {
         label: fileName,
         path: filePath,


### PR DESCRIPTION
Resolves https://github.com/HubSpot/hubspot-cms-vscode/issues/248

Minor oversight! We sort default directory contents when we split between themes & modules like we do in DMUI. But we don't sort the rest of the remote directory contents. This fixes that! 

Waiting to ship this out until after INBOUND.