### PR TITLE
Fix `is not` syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To enable Emmet on your `html-hubl` files, you can map `html-hubl` to `html` in 
 
 ### IntelliSense Suggestions
 
-If you are would like to get IntelliSense suggestions when in snippet placeholders, you will need to add the following to your user settings:
+If you would like to get IntelliSense suggestions when in snippet placeholders, you will need to add the following to your user settings:
 
 `"editor.suggest.snippetsPreventQuickSuggestions": false`
 

--- a/syntaxes/hubl.json
+++ b/syntaxes/hubl.json
@@ -107,6 +107,10 @@
           "match": "\\s*\\b(filter)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\b"
         },
         {
+          "match": "\\b(and|else|if|in|import|(is )?not|or|recursive|with(out)?\\s+context)\\b",
+          "name": "keyword.control.hubl"
+        },
+        {
           "captures": {
             "1": {
               "name": "keyword.control.hubl"
@@ -115,7 +119,7 @@
               "name": "variable.other.hubl.test"
             }
           },
-          "match": "\\s*\\b(is)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\b"
+          "match": "\\s*\\b(is)(?!\\s+not)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\b"
         },
         {
           "captures": {
@@ -124,10 +128,6 @@
             }
           },
           "match": "(?<=\\{\\%-|\\{\\%)\\s*\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b(?!\\s*[,=])"
-        },
-        {
-          "match": "\\b(and|else|if|in|import|not|or|recursive|with(out)?\\s+context)\\b",
-          "name": "keyword.control.hubl"
         },
         {
           "match": "\\b(true|false|none)\\b",


### PR DESCRIPTION
Context: Issue #257 

The token `is not` was being incorrectly captured in our syntax. This PR updates the syntax regex to correctly capture this token. Here is a test snippet from the original issue, and the updated syntax highlighting:

```html
  <div>
    {%- if classes and (classes is string) -%}
        {% set classes = classes|split(" ") %}
    {%- elif (classes is not string) and not (classes is string) or not foo -%}
        {% set classes = classes|split(",") %}
    {%- elif (classes is not string) and (classes is not iterable) or not foo -%}
        {% set classes = [] %}
    {%- endif -%}
  </div>
```

### Before
![Screen capture 2024-01-26 at 12 30@2x](https://github.com/HubSpot/hubspot-cms-vscode/assets/48874841/26ac9a06-5ae4-4425-aa97-f4809834febd)


### After
![Screen capture 2024-01-26 at 12 30@2x](https://github.com/HubSpot/hubspot-cms-vscode/assets/48874841/aefab18e-e60a-4622-9304-cf35808d5751)
