### PR TITLE
Fix fetch

### DIFF
--- a/src/lib/commands/remoteFs.ts
+++ b/src/lib/commands/remoteFs.ts
@@ -65,14 +65,21 @@ export const registerCommands = (context: ExtensionContext) => {
         const downloadingStatus = buildStatusBarItem('Downloading...');
         downloadingStatus.show();
         trackEvent(TRACKED_EVENTS.REMOTE_FS.FETCH);
-        await downloadFileOrFolder({
-          accountId: getAccountId(),
-          src: remoteFilePath,
-          dest: localFilePath,
-          options: {
-            overwrite: true,
-          },
-        });
+        try {
+          await downloadFileOrFolder(
+            getAccountId(),
+            remoteFilePath,
+            localFilePath,
+            undefined,
+            {
+              overwrite: true,
+            }
+          );
+        } catch (error) {
+          window.showErrorMessage(
+            `Failed to fetch ${remoteFilePath}: ${error}`
+          );
+        }
         window.showInformationMessage(
           `Finished download of "${remoteFilePath}" to "${localFilePath}"!`
         );


### PR DESCRIPTION
Fetch API changed slightly here and broke during the LDL migration also - must have missed it in manual testing

Reported in: https://github.com/HubSpot/hubspot-cms-vscode/issues/272

User also reports having errors during watch - I've been unable to reproduce testing in Windows 11 VM, poking them for more info.