### PR TITLE
1.13.1 to fix trackUsage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "hubl",
             "version": "1.3.1",
             "dependencies": {
-                "@hubspot/local-dev-lib": "^1.3.0",
+                "@hubspot/local-dev-lib": "^1.13.1",
                 "dayjs": "^1.11.7",
                 "findup-sync": "^5.0.0",
                 "fs-extra": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -587,7 +587,7 @@
         ]
     },
     "dependencies": {
-        "@hubspot/local-dev-lib": "^1.3.0",
+        "@hubspot/local-dev-lib": "^1.13.1",
         "dayjs": "^1.11.7",
         "findup-sync": "^5.0.0",
         "fs-extra": "^9.0.1",


### PR DESCRIPTION
Tested a bit and there don't seem to be any regressions (and if it's properly following semver there shouldn't be since this is a minor version diff `1.3.0 -> 1.13.1`)

Bumping LDL seems to fix trackUsage on its own; I'm still not quite sure the exact cause but there's a slightly updated implementation of trackUsage on their end that fixes it.