### PR TITLE
Update VS code to be compatible with the global config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "hubl",
-    "version": "1.4.2",
+    "version": "1.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "hubl",
-            "version": "1.4.2",
+            "version": "1.5.0",
             "dependencies": {
                 "@hubspot/local-dev-lib": "^3.1.0",
                 "@hubspot/project-parsing-lib": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "hubl",
             "version": "1.5.0",
             "dependencies": {
-                "@hubspot/local-dev-lib": "^3.1.0",
+                "@hubspot/local-dev-lib": "^3.7.0",
                 "@hubspot/project-parsing-lib": "0.2.0",
                 "dayjs": "^1.11.7",
                 "debounce": "1.2.1",
@@ -218,7 +218,9 @@
             "license": "MIT"
         },
         "node_modules/@hubspot/local-dev-lib": {
-            "version": "3.5.4",
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/@hubspot/local-dev-lib/-/local-dev-lib-3.7.0.tgz",
+            "integrity": "sha512-4FoKRQCuyzKj+VOhcAKCnEFoU85C6kXs+Qqn27zgneko5jH0wqqD26rdwGkcZaY7vVc8sdY73aJLDiUeAN9rCg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "address": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -587,7 +587,7 @@
         ]
     },
     "dependencies": {
-        "@hubspot/local-dev-lib": "^3.1.0",
+        "@hubspot/local-dev-lib": "^3.7.0",
         "@hubspot/project-parsing-lib": "0.2.0",
         "dayjs": "^1.11.7",
         "debounce": "1.2.1",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,6 +6,8 @@ import {
   validateConfig,
   setConfig,
   setConfigPath,
+  configFileExists,
+  getConfigPath,
 } from '@hubspot/local-dev-lib/config';
 
 const onLoadPath = (configPath: string) => {
@@ -23,14 +25,19 @@ export const loadHubspotConfigFile = (rootPath: string) => {
   }
 
   console.log(`rootPath: ${rootPath}`);
+  let path = findConfig(rootPath);
 
-  const path = findConfig(rootPath);
+  // No legacy config found, try the global path
+  if (!path) {
+    path = getConfigPath(undefined, true);
+  }
 
   console.log(`path: ${path}`);
 
   if (!path) {
     return;
   }
+
   onLoadPath(path);
 
   loadConfig(path);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,4 @@
-import { commands } from 'vscode';
+import { commands, window } from 'vscode';
 import { COMMANDS, EVENTS } from './constants';
 import {
   findConfig,
@@ -6,9 +6,14 @@ import {
   validateConfig,
   setConfig,
   setConfigPath,
-  configFileExists,
   getConfigPath,
 } from '@hubspot/local-dev-lib/config';
+import {
+  getDeprecatedConfig,
+  getGlobalConfig,
+  mergeConfigProperties,
+  mergeExistingConfigs,
+} from '@hubspot/local-dev-lib/config/migrate';
 
 const onLoadPath = (configPath: string) => {
   commands.executeCommand('setContext', 'hubspot.configPath', configPath);
@@ -24,29 +29,66 @@ export const loadHubspotConfigFile = (rootPath: string) => {
     return;
   }
 
-  console.log(`rootPath: ${rootPath}`);
-  let path = findConfig(rootPath);
+  const deprecatedConfigPath = findConfig(rootPath);
+  const globalConfigPath = getConfigPath(undefined, true);
 
-  // No legacy config found, try the global path
-  if (!path) {
-    path = getConfigPath(undefined, true);
-  }
+  const resolvedConfigPath = globalConfigPath || deprecatedConfigPath;
 
-  console.log(`path: ${path}`);
-
-  if (!path) {
+  if (!resolvedConfigPath) {
     return;
   }
 
-  onLoadPath(path);
+  // We need to call loadConfig to ensure the isActive() check returns true for global config
+  loadConfig(resolvedConfigPath);
 
-  loadConfig(path);
+  if (deprecatedConfigPath && globalConfigPath) {
+    const mergeConfigCopy = 'Merge accounts';
+    window
+      .showWarningMessage(
+        `Found both global and deprecated account configuration files. Click "Merge configuration files" to merge them automatically.`,
+        mergeConfigCopy
+      )
+      .then((selection) => {
+        if (selection === mergeConfigCopy) {
+          window.showInformationMessage(
+            `Merging accounts from ${deprecatedConfigPath} into ${globalConfigPath}. Your existing configuration file will be archived.`
+          );
+
+          const deprecatedConfig = getDeprecatedConfig(deprecatedConfigPath);
+          const globalConfig = getGlobalConfig();
+
+          let success = false;
+          try {
+            const { initialConfig: GlobalConfigWithPropertiesMerged } =
+              mergeConfigProperties(globalConfig!, deprecatedConfig!, true);
+
+            mergeExistingConfigs(
+              GlobalConfigWithPropertiesMerged,
+              deprecatedConfig!
+            );
+            success = true;
+          } catch (error) {
+            throw new Error('Error merging configuration files: ' + error);
+          }
+
+          if (success) {
+            window.showInformationMessage(`Config files successfully merged.`);
+            initializeConfig(rootPath);
+          }
+        }
+      });
+    return;
+  }
+
+  onLoadPath(resolvedConfigPath);
 
   if (!validateConfig()) {
-    throw new Error(`Invalid config could not be loaded: ${path}`);
+    throw new Error(
+      `Invalid config could not be loaded: ${resolvedConfigPath}`
+    );
   } else {
     commands.executeCommand(EVENTS.ON_CONFIG_UPDATED);
-    return path;
+    return resolvedConfigPath;
   }
 };
 

--- a/src/lib/commands/account.ts
+++ b/src/lib/commands/account.ts
@@ -1,5 +1,6 @@
 import { commands, ExtensionContext, Uri } from 'vscode';
 import { CLIAccount_DEPRECATED } from '@hubspot/local-dev-lib/types/Accounts';
+import { getAccountIdentifier } from '@hubspot/local-dev-lib/config/getAccountIdentifier';
 import { COMMANDS } from '../constants';
 
 export const registerCommands = (context: ExtensionContext) => {
@@ -9,7 +10,7 @@ export const registerCommands = (context: ExtensionContext) => {
       async (hubspotAccount: CLIAccount_DEPRECATED) => {
         const pakUrl = `https://app.hubspot${
           hubspotAccount.env === 'qa' ? 'qa' : ''
-        }.com/personal-access-key/${hubspotAccount.portalId}`;
+        }.com/personal-access-key/${getAccountIdentifier(hubspotAccount)}`;
 
         commands.executeCommand('vscode.open', Uri.parse(pakUrl));
       }
@@ -21,7 +22,7 @@ export const registerCommands = (context: ExtensionContext) => {
       async (hubspotAccount: CLIAccount_DEPRECATED) => {
         const designManagerUrl = `https://app.hubspot${
           hubspotAccount.env === 'qa' ? 'qa' : ''
-        }.com/design-manager/${hubspotAccount.portalId}`;
+        }.com/design-manager/${getAccountIdentifier(hubspotAccount)}`;
 
         commands.executeCommand('vscode.open', Uri.parse(designManagerUrl));
       }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,10 +1,9 @@
 import { dirname } from 'path';
 import { window, commands, workspace, StatusBarAlignment } from 'vscode';
 import { getAccountId } from '@hubspot/local-dev-lib/config';
-
-import { COMMANDS } from './constants';
-import { CLIConfig } from '@hubspot/local-dev-lib/types/Config';
 import { CLIAccount_DEPRECATED } from '@hubspot/local-dev-lib/types/Accounts';
+import { getAccountIdentifier } from '@hubspot/local-dev-lib/config/getAccountIdentifier';
+import { COMMANDS } from './constants';
 
 const { exec } = require('node:child_process');
 
@@ -17,24 +16,13 @@ export const getRootPath = () => {
   return workspaceFolders[0].uri.fsPath;
 };
 
-export const getDefaultPortalFromConfig = (config: CLIConfig) => {
-  return (
-    config &&
-    'portals' in config &&
-    config.portals &&
-    config.portals.find(
-      (p: CLIAccount_DEPRECATED) =>
-        p.portalId === config.defaultPortal || p.name === config.defaultPortal
-    )
-  );
-};
-
 export const getDisplayedHubspotPortalInfo = (
   portalData: CLIAccount_DEPRECATED
 ) => {
+  const accountIdentifier = getAccountIdentifier(portalData);
   return portalData.name
-    ? `${portalData.name} - ${portalData.portalId}`
-    : `${portalData.portalId}`;
+    ? `${portalData.name} - ${accountIdentifier}`
+    : `${accountIdentifier}`;
 };
 
 export const runTerminalCommand = async (

--- a/src/lib/statusBar.ts
+++ b/src/lib/statusBar.ts
@@ -6,7 +6,10 @@ import {
   ThemeColor,
 } from 'vscode';
 import { COMMANDS } from './constants';
-import { getConfig } from '@hubspot/local-dev-lib/config';
+import {
+  getConfig,
+  getConfigDefaultAccount,
+} from '@hubspot/local-dev-lib/config';
 
 let hsStatusBar: StatusBarItem;
 
@@ -14,8 +17,8 @@ export const updateStatusBarItems = () => {
   console.log('updateStatusBarItems');
 
   const config = getConfig();
-  // @ts-expect-error Need to update to use new global config
-  const defaultAccount = config && config.defaultPortal;
+
+  const defaultAccount = config && getConfigDefaultAccount();
 
   if (defaultAccount) {
     hsStatusBar.text = `$(arrow-swap) ${defaultAccount}`;
@@ -25,7 +28,7 @@ export const updateStatusBarItems = () => {
   } else {
     hsStatusBar.text = `$(extensions-warning-message) No Default HubSpot Account`;
     hsStatusBar.tooltip =
-      'There is currently no default HubSpot account set within the config. Click here to select a defaultPortal.';
+      'There is currently no default HubSpot account set within the config. Click here to select a defaultAccount.';
     hsStatusBar.backgroundColor = new ThemeColor(
       'statusBarItem.warningBackground'
     );

--- a/src/lib/uri.ts
+++ b/src/lib/uri.ts
@@ -81,7 +81,7 @@ const handleAuthRequest = async (authParams: URLSearchParams) => {
     .then(async (answer: string | undefined) => {
       if (answer === 'Yes') {
         await trackEvent(TRACKED_EVENTS.SET_DEFAULT_ACCOUNT);
-        console.log(`Updating defaultPortal to ${accountIdentifier}.`);
+        console.log(`Updating defaultAccount to ${accountIdentifier}.`);
         commands.executeCommand(
           COMMANDS.CONFIG.SET_DEFAULT_ACCOUNT,
           accountIdentifier


### PR DESCRIPTION
This leverages all the utils from LDL that help with global config compatibility. The tldr is that we shouldn't directly reference `portalId` or `defaultAccount` anymore.

I also made a fix to the account delete and rename actions. They work correctly, but they weren't refreshing the accounts section after performing the updates which makes it look like it isn't working.